### PR TITLE
Update VehicleReportResponseDto constructor parameters

### DIFF
--- a/transport.application/VehicleBusiness/VehicleBusiness.cs
+++ b/transport.application/VehicleBusiness/VehicleBusiness.cs
@@ -113,7 +113,7 @@ public class VehicleBusiness : IVehicleBusiness
 
         var pagedResult = await query.ToPagedReportAsync<VehicleReportResponseDto, Vehicle, VehicleReportFilterRequestDto>(
             requestDto,
-            selector: v => new VehicleReportResponseDto(v.VehicleTypeId, v.VehicleTypeId, v.InternalNumber, v.VehicleType.Name, v.VehicleType.Quantity, v.VehicleType.ImageBase64),
+            selector: v => new VehicleReportResponseDto(v.VehicleId, v.VehicleTypeId, v.InternalNumber, v.VehicleType.Name, v.VehicleType.Quantity, v.VehicleType.ImageBase64),
             sortMappings: sortMappings
         );
 


### PR DESCRIPTION
Changed the first parameter in the VehicleReportResponseDto constructor from `v.VehicleTypeId` to `v.VehicleId` in VehicleBusiness.cs to reflect the correct data usage for report generation.