### PR TITLE
Enhance DTOs and tests with status properties

### DIFF
--- a/Transport.Tests/DriverBusinessTests.cs
+++ b/Transport.Tests/DriverBusinessTests.cs
@@ -14,7 +14,7 @@ using Transport.Domain.Vehicles;
 
 namespace Transport.Tests.DriverBusinessTests;
 
-public class DriverBusinessTests: TestBase
+public class DriverBusinessTests : TestBase
 {
     private readonly Mock<IApplicationDbContext> _contextMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
@@ -211,6 +211,7 @@ public class DriverBusinessTests: TestBase
             FirstName = "Juan",
             LastName = "Pérez",
             DocumentNumber = "1234",
+            Status = EntityStatusEnum.Active,
             Reserves = new List<Reserve>
             {
                 new Reserve
@@ -227,6 +228,7 @@ public class DriverBusinessTests: TestBase
             FirstName = "Ana",
             LastName = "Gomez",
             DocumentNumber = "5678",
+            Status = EntityStatusEnum.Active,
             Reserves = new List<Reserve>()
         }
     };
@@ -249,6 +251,8 @@ public class DriverBusinessTests: TestBase
         result.IsSuccess.Should().BeTrue();
         result.Value.Items.Should().HaveCount(1);
         result.Value.Items.First().FirstName.Should().Be("Juan");
+        result.Value.Items.First().Status.Should().Be("Active");
+
         result.Value.Items.First().Reserves.Should().HaveCount(1);
     }
 

--- a/transport.application/CityBusiness/CityBusiness.cs
+++ b/transport.application/CityBusiness/CityBusiness.cs
@@ -79,7 +79,7 @@ public class CityBusiness : ICityBusiness
 
         var pagedResult = await query.ToPagedReportAsync<CityReportResponseDto, City, CityReportFilterRequestDto>(
             requestDto,
-            selector: v => new CityReportResponseDto(v.Name, v.Code),
+            selector: v => new CityReportResponseDto(v.CityId, v.Name, v.Code),
             sortMappings: sortMappings
         );
 

--- a/transport.application/DriverBusiness/DriverBusiness.cs
+++ b/transport.application/DriverBusiness/DriverBusiness.cs
@@ -97,6 +97,7 @@ public class DriverBusiness : IDriverBusiness
                 FirstName = d.FirstName,
                 LastName = d.LastName,
                 DocumentNumber = d.DocumentNumber,
+                Status = d.Status.ToString(),
                 Reserves = d.Reserves.Select(r => new DriverReserveReportResponseDto
                 {
                     ReserveDate = r.ReserveDate,

--- a/transport.application/ServiceBusiness/ServiceBusiness.cs
+++ b/transport.application/ServiceBusiness/ServiceBusiness.cs
@@ -128,7 +128,7 @@ public class ServiceBusiness : IServiceBusiness
                     s.Vehicle.VehicleType.Quantity, 
                     s.Vehicle.VehicleType.Name, 
                     s.Vehicle.VehicleType.ImageBase64),
-                s.Status
+                s.Status.ToString()
             ),
             sortMappings: sortMappings
         );

--- a/transport.application/VehicleBusiness/VehicleBusiness.cs
+++ b/transport.application/VehicleBusiness/VehicleBusiness.cs
@@ -110,7 +110,7 @@ public class VehicleBusiness : IVehicleBusiness
 
         var pagedResult = await query.ToPagedReportAsync<VehicleReportResponseDto, Vehicle, VehicleReportFilterRequestDto>(
             requestDto,
-            selector: v => new VehicleReportResponseDto(v.VehicleId, v.VehicleTypeId, v.InternalNumber, v.VehicleType.Name, v.VehicleType.Quantity, v.VehicleType.ImageBase64),
+            selector: v => new VehicleReportResponseDto(v.VehicleId, v.VehicleTypeId, v.InternalNumber, v.VehicleType.Name, v.VehicleType.Quantity, v.VehicleType.ImageBase64, v.Status.ToString()),
             sortMappings: sortMappings
         );
 

--- a/transport.application/VehicleTypeBusiness/VehicleTypeBusiness.cs
+++ b/transport.application/VehicleTypeBusiness/VehicleTypeBusiness.cs
@@ -39,9 +39,9 @@ public class VehicleTypeBusiness : IVehicleTypeBusiness
         if (dto.Vehicles is not null && dto.Vehicles.Any())
         {
             vehicleType.Vehicles = dto.Vehicles.Select(p => new Vehicle()
-            { 
-                VehicleTypeId = vehicleType.VehicleTypeId, 
-                InternalNumber = p.InternalNumber,                
+            {
+                VehicleTypeId = vehicleType.VehicleTypeId,
+                InternalNumber = p.InternalNumber,
             }).ToList();
         }
 
@@ -85,7 +85,7 @@ public class VehicleTypeBusiness : IVehicleTypeBusiness
 
         var pagedResult = await query.ToPagedReportAsync<VehicleTypeReportResponseDto, VehicleType, VehicleTypeReportFilterRequestDto>(
             requestDto,
-            selector: v => new VehicleTypeReportResponseDto(v.VehicleTypeId, v.Name, v.ImageBase64, v.Quantity),
+            selector: v => new VehicleTypeReportResponseDto(v.VehicleTypeId, v.Name, v.ImageBase64, v.Quantity, v.Status.ToString()),
             sortMappings: sortMappings
         );
 

--- a/transport.common/Contracts/City/CityReportResponseDto.cs
+++ b/transport.common/Contracts/City/CityReportResponseDto.cs
@@ -1,4 +1,4 @@
 ﻿
 namespace Transport.SharedKernel.Contracts.City;
 
-public record CityReportResponseDto(string Name, string Code);
+public record CityReportResponseDto(int Id, string Name, string Code);

--- a/transport.common/Contracts/Driver/DriverReportResponseDto.cs
+++ b/transport.common/Contracts/Driver/DriverReportResponseDto.cs
@@ -7,6 +7,7 @@ public class DriverReportResponseDto
     public string LastName { get; set; } = null!;
     public string DocumentNumber { get; set; } = null!;
     public int VehicleInternalNumber { get; set; }
+    public string Status { get; set; }
 
     public List<DriverReserveReportResponseDto> Reserves { get; set; } = new();
 }

--- a/transport.common/Contracts/Service/ServiceReportResponseDto.cs
+++ b/transport.common/Contracts/Service/ServiceReportResponseDto.cs
@@ -9,6 +9,6 @@ public record ServiceReportResponseDto(
     TimeSpan DepartureHour,
     bool IsHoliday,
     ServiceVehicleResponseDto Vehicle,
-    EntityStatusEnum Status);
+    string Status);
 
 public record ServiceVehicleResponseDto(string InternalNumber, int AvailableQuantity, int FullQuantity, string VehicleTypeName, string? Image);

--- a/transport.common/Contracts/Vehicle/VehicleReportResponseDto.cs
+++ b/transport.common/Contracts/Vehicle/VehicleReportResponseDto.cs
@@ -5,5 +5,6 @@ public record VehicleReportResponseDto(int VehicleId,
     string InternalNumber,
     string VehicleTypeName,
     int VehicleTypeQuantity,
-    string? ImageBase64
+    string? ImageBase64,
+    string status
 );

--- a/transport.common/Contracts/VehicleType/VehicleTypeReportResponseDto.cs
+++ b/transport.common/Contracts/VehicleType/VehicleTypeReportResponseDto.cs
@@ -4,5 +4,6 @@ public record VehicleTypeReportResponseDto(
     int VehicleTypeId,
     string Name,
     string? ImageBase64,
-    int Quantity
+    int Quantity,
+    string status
 );


### PR DESCRIPTION
- Updated `DriverBusinessTests` to include `Status` for drivers and added assertions for status and reserves.
- Modified `CityBusiness` to include `CityId` in `CityReportResponseDto`.
- Converted `Status` properties to strings in `DriverBusiness`, `ServiceBusiness`, `VehicleBusiness`, and `VehicleTypeBusiness` for consistency.
- Added `Status` property to `VehicleReportResponseDto` and `VehicleTypeReportResponseDto`.
- Changed `CityReportResponseDto` to include an `Id` property.
- Updated `DriverReportResponseDto` and `ServiceReportResponseDto` to include `Status` as a string.