### PR TITLE
Add Lat and Lng columns to Direction table

### DIFF
--- a/idempotent.sql
+++ b/idempotent.sql
@@ -269,3 +269,19 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+ALTER TABLE [Direction] ADD [Lat] float NULL;
+GO
+
+ALTER TABLE [Direction] ADD [Lng] float NULL;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250504002738_InitialMigration-pt2', N'8.0.14');
+GO
+
+COMMIT;
+GO
+

--- a/transport.infraestructure/Migrations/20250504002738_InitialMigration-pt2.Designer.cs
+++ b/transport.infraestructure/Migrations/20250504002738_InitialMigration-pt2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Transport.Infraestructure.Database;
 
@@ -11,9 +12,11 @@ using Transport.Infraestructure.Database;
 namespace Transport.Infraestructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250504002738_InitialMigration-pt2")]
+    partial class InitialMigrationpt2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/transport.infraestructure/Migrations/20250504002738_InitialMigration-pt2.cs
+++ b/transport.infraestructure/Migrations/20250504002738_InitialMigration-pt2.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transport.Infraestructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialMigrationpt2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Lat",
+                table: "Direction",
+                type: "float",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Lng",
+                table: "Direction",
+                type: "float",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Lat",
+                table: "Direction");
+
+            migrationBuilder.DropColumn(
+                name: "Lng",
+                table: "Direction");
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces two new columns, `Lat` and `Lng`, of type `float` to the `Direction` table in the database schema. The migration files have been updated to include these changes, with the `Up` method adding the columns and the `Down` method providing a rollback option. The `ApplicationDbContextModelSnapshot` has also been modified to reflect these new properties, ensuring that the Entity Framework Core context is aware of the updates. The migration history is updated accordingly.