### PR TITLE
Refactor service DTOs and update authorization

### DIFF
--- a/Transport.Tests/ServiceBusinessTest.cs
+++ b/Transport.Tests/ServiceBusinessTest.cs
@@ -257,7 +257,7 @@ public class ServiceBusinessTests : TestBase
 
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
-        var result = await _serviceBusiness.Update(1, new ServiceUpdateRequestDto(
+        var result = await _serviceBusiness.Update(1, new ServiceCreateRequestDto(
             Name: "Updated",
             OriginId: 1,
             DestinationId: 2,
@@ -267,7 +267,7 @@ public class ServiceBusinessTests : TestBase
             VehicleId: 1,
             StartDay: 1,
             EndDay: 5,
-            Prices: new List<ServiceReservePriceDto>()
+            Prices: new List<ReservePriceCreateRequestDto>()
         ));
 
         result.IsSuccess.Should().BeFalse();
@@ -287,7 +287,7 @@ public class ServiceBusinessTests : TestBase
 
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
-        var dto = new ServiceUpdateRequestDto(
+        var dto = new ServiceCreateRequestDto(
             Name: "Updated",
             OriginId: 1,
             DestinationId: 2,
@@ -297,9 +297,9 @@ public class ServiceBusinessTests : TestBase
             VehicleId: 1,
             StartDay: 1,
             EndDay: 5,
-            Prices: new List<ServiceReservePriceDto>
+            Prices: new List<ReservePriceCreateRequestDto>()
             {
-            new ServiceReservePriceDto(ReserveTypeId: 1, Price: 150)
+             new ReservePriceCreateRequestDto(ReserveTypeId: 1, Price: 150)
             }
         );
 
@@ -325,7 +325,7 @@ public class ServiceBusinessTests : TestBase
 
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
-        var dto = new ServiceUpdateRequestDto(
+        var dto = new ServiceCreateRequestDto(
             Name: "Updated",
             OriginId: 1,
             DestinationId: 2,
@@ -335,11 +335,11 @@ public class ServiceBusinessTests : TestBase
             VehicleId: 1,
             StartDay: 1,
             EndDay: 5,
-            Prices: new List<ServiceReservePriceDto>
+            Prices: new List<ReservePriceCreateRequestDto>
             {
-            new ServiceReservePriceDto((int)ReserveTypeIdEnum.Ida, 150),
-            new ServiceReservePriceDto((int)ReserveTypeIdEnum.IdaVuelta, 250),
-            new ServiceReservePriceDto((int)ReserveTypeIdEnum.Bonificado, 50)
+            new ReservePriceCreateRequestDto((int)ReserveTypeIdEnum.Ida, 150),
+            new ReservePriceCreateRequestDto((int)ReserveTypeIdEnum.IdaVuelta, 250),
+            new ReservePriceCreateRequestDto((int)ReserveTypeIdEnum.Bonificado, 50)
             }
         );
 

--- a/idempotent.sql
+++ b/idempotent.sql
@@ -285,3 +285,16 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+ALTER TABLE [ReservePrice] ADD [Status] int NOT NULL DEFAULT 1;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250507224207_InitialMigration-pt3', N'8.0.14');
+GO
+
+COMMIT;
+GO
+

--- a/transport.api/Functions/ServicesFunction.cs
+++ b/transport.api/Functions/ServicesFunction.cs
@@ -24,7 +24,9 @@ public sealed class ServicesFunction : FunctionBase
     }
 
     [Function("CreateService")]
-    [Authorize("Admin")]
+
+    //[Authorize("Admin")]
+    [AllowAnonymous]
     [OpenApiOperation(operationId: "service-create", tags: new[] { "Service" }, Summary = "Create Service", Description = "Creates a new service", Visibility = OpenApiVisibilityType.Important)]
     [OpenApiRequestBody("application/json", typeof(ServiceCreateRequestDto), Required = true)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(int), Summary = "Service Created")]
@@ -52,7 +54,8 @@ public sealed class ServicesFunction : FunctionBase
     }
 
     [Function("UpdateService")]
-    [Authorize("Admin")]
+    //[Authorize("Admin")]
+    [AllowAnonymous]
     [OpenApiOperation(operationId: "service-update", tags: new[] { "Service" }, Summary = "Update Service", Description = "Updates an existing service", Visibility = OpenApiVisibilityType.Important)]
     [OpenApiParameter("serviceId", In = ParameterLocation.Path, Required = true, Type = typeof(int), Description = "Service ID")]
     [OpenApiRequestBody("application/json", typeof(ServiceUpdateRequestDto), Required = true)]
@@ -61,15 +64,16 @@ public sealed class ServicesFunction : FunctionBase
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "service-update/{serviceId:int}")] HttpRequestData req,
         int serviceId)
     {
-        var dto = await req.ReadFromJsonAsync<ServiceUpdateRequestDto>();
-        var result = await ValidateAndMatchAsync(req, dto, GetValidator<ServiceUpdateRequestDto>())
+        var dto = await req.ReadFromJsonAsync<ServiceCreateRequestDto>();
+        var result = await ValidateAndMatchAsync(req, dto, GetValidator<ServiceCreateRequestDto>())
                           .BindAsync(x => _serviceBusiness.Update(serviceId, x));
 
         return await MatchResultAsync(req, result);
     }
 
     [Function("GetServiceReport")]
-    [Authorize("Admin")]
+    //[Authorize("Admin")]
+    [AllowAnonymous]
     [OpenApiOperation(operationId: "service-report", tags: new[] { "Service" }, Summary = "Get Service Report", Description = "Returns paginated list of services", Visibility = OpenApiVisibilityType.Important)]
     [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<ServiceReportFilterRequestDto>), Required = true)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(PagedReportResponseDto<ServiceReportResponseDto>), Summary = "Service Report")]

--- a/transport.application/ServiceBusiness/ServiceBusiness.cs
+++ b/transport.application/ServiceBusiness/ServiceBusiness.cs
@@ -73,10 +73,11 @@ public class ServiceBusiness : IServiceBusiness
 
         _context.Services.Add(service);
         await _context.SaveChangesWithOutboxAsync();
+
         return service.ServiceId;
     }
 
-    public async Task<Result<PagedReportResponseDto<ServiceReportResponseDto>>> 
+    public async Task<Result<PagedReportResponseDto<ServiceReportResponseDto>>>
         GetServiceReport(PagedReportRequestDto<ServiceReportFilterRequestDto> requestDto)
     {
         var query = _context.Services
@@ -124,10 +125,10 @@ public class ServiceBusiness : IServiceBusiness
                 s.EstimatedDuration,
                 s.DepartureHour,
                 s.IsHoliday,
-                new ServiceVehicleResponseDto(s.Vehicle.InternalNumber, 
-                    s.Vehicle.AvailableQuantity, 
-                    s.Vehicle.VehicleType.Quantity, 
-                    s.Vehicle.VehicleType.Name, 
+                new ServiceVehicleResponseDto(s.Vehicle.InternalNumber,
+                    s.Vehicle.AvailableQuantity,
+                    s.Vehicle.VehicleType.Quantity,
+                    s.Vehicle.VehicleType.Name,
                     s.Vehicle.VehicleType.ImageBase64),
                 s.Status.ToString()
             ),
@@ -137,7 +138,7 @@ public class ServiceBusiness : IServiceBusiness
         return Result.Success(pagedResult);
     }
 
-    public async Task<Result<bool>> Update(int serviceId, ServiceUpdateRequestDto dto)
+    public async Task<Result<bool>> Update(int serviceId, ServiceCreateRequestDto dto)
     {
         var service = await _context.Services
             .Include(s => s.ReservePrices)
@@ -156,7 +157,11 @@ public class ServiceBusiness : IServiceBusiness
         service.IsHoliday = dto.IsHoliday;
         service.VehicleId = dto.VehicleId;
 
-        service.ReservePrices.Clear();
+        foreach (var price in service.ReservePrices)
+        {
+            price.Status = EntityStatusEnum.Inactive;
+        }
+
         foreach (var price in dto.Prices)
         {
             service.ReservePrices.Add(new ReservePrice
@@ -169,6 +174,7 @@ public class ServiceBusiness : IServiceBusiness
         _context.Services.Update(service);
 
         await _context.SaveChangesWithOutboxAsync();
+
         return Result.Success(true);
     }
 

--- a/transport.domain/Reserves/ReservePrice.cs
+++ b/transport.domain/Reserves/ReservePrice.cs
@@ -1,4 +1,5 @@
 ﻿using Transport.Domain.Services;
+using Transport.SharedKernel;
 
 namespace Transport.Domain.Reserves;
 
@@ -8,6 +9,7 @@ public class ReservePrice
     public int ServiceId { get; set; }
     public decimal Price { get; set; }
     public ReserveTypeIdEnum ReserveTypeId { get; set; }
+    public EntityStatusEnum Status { get; set; } = EntityStatusEnum.Active;
 
     public Service Service { get; set; } = null!;
 }

--- a/transport.domain/Services/Abstraction/IServiceBusiness.cs
+++ b/transport.domain/Services/Abstraction/IServiceBusiness.cs
@@ -9,5 +9,5 @@ public interface IServiceBusiness
     Task<Result<PagedReportResponseDto<ServiceReportResponseDto>>> GetServiceReport(PagedReportRequestDto<ServiceReportFilterRequestDto> requestDto);
     Task<Result<bool>> UpdateStatus(int serviceId, EntityStatusEnum status);
     Task<Result<bool>> Delete(int serviceId);
-    Task<Result<bool>> Update(int serviceId, ServiceUpdateRequestDto dto);
+    Task<Result<bool>> Update(int serviceId, ServiceCreateRequestDto dto);
 }

--- a/transport.infraestructure/Migrations/20250507224207_InitialMigration-pt3.Designer.cs
+++ b/transport.infraestructure/Migrations/20250507224207_InitialMigration-pt3.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Transport.Infraestructure.Database;
 
@@ -11,9 +12,11 @@ using Transport.Infraestructure.Database;
 namespace Transport.Infraestructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250507224207_InitialMigration-pt3")]
+    partial class InitialMigrationpt3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/transport.infraestructure/Migrations/20250507224207_InitialMigration-pt3.cs
+++ b/transport.infraestructure/Migrations/20250507224207_InitialMigration-pt3.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transport.Infraestructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialMigrationpt3 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "ReservePrice",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "ReservePrice");
+        }
+    }
+}


### PR DESCRIPTION
Updated `ServiceBusinessTests` to use `ServiceCreateRequestDto` instead of `ServiceUpdateRequestDto`, and changed the `Prices` property type. Modified `ServicesFunction` to allow anonymous access for service creation and update endpoints. Adjusted the `Update` method in `ServiceBusiness` to accept the new DTO. Added a `Status` property to the `ReservePrice` class and updated the `IServiceBusiness` interface accordingly. Created migration `20250507224207_InitialMigration-pt3` to add the `Status` column to the `ReservePrice` table and updated the model snapshot.