### PR TITLE
Refactor Driver and User Business Tests

### DIFF
--- a/Transport.Tests/DriverBusinessTests.cs
+++ b/Transport.Tests/DriverBusinessTests.cs
@@ -17,15 +17,13 @@ namespace Transport.Tests.DriverBusinessTests;
 public class DriverBusinessTests : TestBase
 {
     private readonly Mock<IApplicationDbContext> _contextMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly IDriverBusiness _driverBusiness;
 
     public DriverBusinessTests()
     {
         _contextMock = new Mock<IApplicationDbContext>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
 
-        _driverBusiness = new DriverBusiness(_unitOfWorkMock.Object, _contextMock.Object);
+        _driverBusiness = new DriverBusiness(_contextMock.Object);
     }
 
     [Fact]


### PR DESCRIPTION
- Removed `IUnitOfWork` mock from `DriverBusinessTests` to simplify dependencies.
- Added `IUnitOfWork` mock to `UserBusinessTests` to align with unit of work patterns.
- Updated mock setups for clarity and maintainability, including variable renaming for consistency.
- Renamed test method `RenewTokenAsync_ShouldSucceed_WhenRefreshTokenIsValid` to `RenewTokenAsync_ShouldSucceed_WhenTokenIsValid` and adjusted assertions accordingly.
- Enhanced overall clarity and functionality of tests to better reflect updated business logic.