### PR TITLE
Change DepartureHour to string in ReserveReportResponseDto

### DIFF
--- a/transport.application/ReserveBusiness/ReserveBusiness.cs
+++ b/transport.application/ReserveBusiness/ReserveBusiness.cs
@@ -200,7 +200,7 @@ public class ReserveBusiness : IReserveBusiness
                 rp.Service.Destination.Name,
                 rp.Service.Vehicle.AvailableQuantity,
                 rp.CustomerReserves.Count,
-                rp.Service.DepartureHour,
+                rp.Service.DepartureHour.ToString(@"hh\:mm"),
                 rp.CustomerReserves
                   .Select(p => new CustomerReserveReportResponseDto(
                       p.CustomerReserveId,

--- a/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
@@ -5,5 +5,5 @@ public record ReserveReportResponseDto(int ReserveId,
     string DestinationName,
     int AvailableQuantity,
     int ReservedQuantity,
-    TimeSpan DepartureHour,
+    string DepartureHour,
     List<CustomerReserveReportResponseDto> Passengers);


### PR DESCRIPTION
Updated the `DepartureHour` property from `TimeSpan` to `string` in the `ReserveReportResponseDto` class. This allows for formatted output as "hh:mm" in the `ReserveBusiness` class, enhancing readability and usability of the departure time.