### PR TITLE
Add Direction feature with business logic and tests

### DIFF
--- a/Transport.Tests/CityBusinessTest.cs
+++ b/Transport.Tests/CityBusinessTest.cs
@@ -8,7 +8,7 @@ using Transport.Domain.Cities.Abstraction;
 using Transport.Business.Data;
 using Xunit;
 using Transport.Domain.Vehicles;
-using Transport.Domain;
+using Transport.Domain.Directions;
 
 namespace Transport.Tests.CityBusinessTests;
 

--- a/Transport.Tests/DirectionBusinessTests.cs
+++ b/Transport.Tests/DirectionBusinessTests.cs
@@ -1,0 +1,92 @@
+﻿using Moq;
+using Transport.Business.Data;
+using Transport.Business.DirectionBusiness;
+using Transport.Domain.Directions;
+using Transport.SharedKernel.Contracts.Direction;
+using Transport.SharedKernel;
+using Xunit;
+using FluentAssertions;
+
+namespace Transport.Tests.DirectionBusinessTests;
+
+public class DirectionBusinessTests : TestBase
+{
+    private readonly Mock<IApplicationDbContext> _contextMock;
+    private readonly DirectionBusiness _directionBusiness;
+
+    public DirectionBusinessTests()
+    {
+        _contextMock = new Mock<IApplicationDbContext>();
+        _directionBusiness = new DirectionBusiness(_contextMock.Object);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldSucceed_WhenValid()
+    {
+        var directions = new List<Direction>();
+        _contextMock.Setup(x => x.Directions).Returns(GetMockDbSetWithIdentity(directions).Object);
+        SetupSaveChangesWithOutboxAsync(_contextMock);
+
+        var dto = new DirectionCreateDto("Calle 123", -34.60, -58.38, 1);
+
+        var result = await _directionBusiness.CreateAsync(dto);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldFail_WhenDirectionNotFound()
+    {
+        _contextMock.Setup(x => x.Directions.FindAsync(It.IsAny<object[]>()))
+            .ReturnsAsync((Direction?)null);
+
+        var dto = new DirectionUpdateDto("Calle Nueva", -34.60, -58.38, 2);
+        var result = await _directionBusiness.UpdateAsync(1, dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(DirectionError.DirectionNotFound);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldSucceed_WhenDirectionExists()
+    {
+        var direction = new Direction { DirectionId = 1, Name = "Vieja", Lat = 0, Lng = 0, CityId = 1 };
+        _contextMock.Setup(x => x.Directions.FindAsync(1)).ReturnsAsync(direction);
+        SetupSaveChangesWithOutboxAsync(_contextMock);
+
+        var dto = new DirectionUpdateDto("Nueva", -34.61, -58.39, 2);
+        var result = await _directionBusiness.UpdateAsync(1, dto);
+
+        result.IsSuccess.Should().BeTrue();
+        direction.Name.Should().Be("Nueva");
+        direction.Lat.Should().Be(-34.61);
+        direction.Lng.Should().Be(-58.39);
+        direction.CityId.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldFail_WhenDirectionNotFound()
+    {
+        _contextMock.Setup(x => x.Directions.FindAsync(It.IsAny<object[]>()))
+            .ReturnsAsync((Direction?)null);
+
+        var result = await _directionBusiness.DeleteAsync(1);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(DirectionError.DirectionNotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldSucceed_WhenDirectionExists()
+    {
+        var direction = new Direction { DirectionId = 1, Status = EntityStatusEnum.Active };
+        _contextMock.Setup(x => x.Directions.FindAsync(1)).ReturnsAsync(direction);
+        SetupSaveChangesWithOutboxAsync(_contextMock);
+
+        var result = await _directionBusiness.DeleteAsync(1);
+
+        result.IsSuccess.Should().BeTrue();
+        direction.Status.Should().Be(EntityStatusEnum.Deleted);
+    }
+}

--- a/Transport.Tests/ServiceBusinessTest.cs
+++ b/Transport.Tests/ServiceBusinessTest.cs
@@ -447,8 +447,8 @@ public class ServiceBusinessTests : TestBase
     {
         // Arrange
         var reserveGenerationDays = 3;
-        var today = DateTime.Today;
-        var feriado = today.AddDays(1); // Mañana es feriado
+        var today = _dateTimeProviderMock.Object.UtcNow;
+        var feriado = today.AddDays(1);
 
         var reserveOptionMock = new Mock<IReserveOption>();
         reserveOptionMock.Setup(x => x.ReserveGenerationDays).Returns(reserveGenerationDays);
@@ -504,7 +504,7 @@ public class ServiceBusinessTests : TestBase
     public async Task GenerateFutureReserves_ShouldCreateReservesOnHolidays_WhenIsHolidayIsTrue()
     {
         // Arrange
-        var today = DateTime.Today;
+        var today = _dateTimeProviderMock.Object.UtcNow;
         var feriado = today.AddDays(2);
 
    

--- a/idempotent.sql
+++ b/idempotent.sql
@@ -617,3 +617,37 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+DECLARE @var3 sysname;
+SELECT @var3 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[Direction]') AND [c].[name] = N'Name');
+IF @var3 IS NOT NULL EXEC(N'ALTER TABLE [Direction] DROP CONSTRAINT [' + @var3 + '];');
+ALTER TABLE [Direction] ALTER COLUMN [Name] VARCHAR(250) NOT NULL;
+GO
+
+ALTER TABLE [Direction] ADD [Status] int NOT NULL DEFAULT 0;
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-05-26T11:33:42.5415717Z'
+WHERE [RoleId] = 1;
+SELECT @@ROWCOUNT;
+
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-05-26T11:33:42.5415719Z'
+WHERE [RoleId] = 2;
+SELECT @@ROWCOUNT;
+
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250526113343_AddStatusInDirection', N'8.0.14');
+GO
+
+COMMIT;
+GO
+

--- a/transport.api/Functions/DirectionFunction.cs
+++ b/transport.api/Functions/DirectionFunction.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi.Models;
+using System.Net;
+using Transport.Domain.Directions.Abstraction;
+using Transport.SharedKernel.Contracts.Direction;
+using Transport.SharedKernel;
+using Transport_Api.Functions.Base;
+using Transport.Infraestructure.Authorization;
+using Transport_Api.Extensions;
+using Transport.SharedKernel.Contracts.City;
+
+namespace transport_api.Functions;
+
+public sealed class DirectionFunction : FunctionBase
+{
+    private readonly IDirectionBusiness _directionBusiness;
+
+    public DirectionFunction(IDirectionBusiness directionBusiness, IServiceProvider serviceProvider)
+        : base(serviceProvider)
+    {
+        _directionBusiness = directionBusiness;
+    }
+
+    [Function("CreateDirection")]
+    [Authorize("Admin")]
+    [OpenApiOperation(operationId: "direction-create", tags: new[] { "Direction" }, Summary = "Create new Direction", Description = "Creates a new direction", Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiRequestBody("application/json", typeof(DirectionCreateDto), Required = true)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(int), Summary = "Direction Created")]
+    public async Task<HttpResponseData> CreateDirection(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "direction-create")] HttpRequestData req)
+    {
+        var dto = await req.ReadFromJsonAsync<DirectionCreateDto>();
+        var result = await ValidateAndMatchAsync(req, dto, GetValidator<DirectionCreateDto>())
+            .BindAsync(_directionBusiness.CreateAsync);
+
+        return await MatchResultAsync(req, result);
+    }
+
+    [Function("UpdateDirection")]
+    [Authorize("Admin")]
+    [OpenApiOperation(operationId: "direction-update", tags: new[] { "Direction" }, Summary = "Update Direction", Description = "Updates an existing direction", Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiRequestBody("application/json", typeof(DirectionUpdateDto), Required = true)]
+    [OpenApiResponseWithoutBody(HttpStatusCode.OK, Summary = "Direction Updated")]
+    public async Task<HttpResponseData> UpdateDirection(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "direction-update/{directionId:int}")] HttpRequestData req, int directionId)
+    {
+        var dto = await req.ReadFromJsonAsync<DirectionUpdateDto>();
+        var result = await ValidateAndMatchAsync(req, dto, GetValidator<DirectionUpdateDto>())
+            .BindAsync(d => _directionBusiness.UpdateAsync(directionId, dto));
+
+        return await MatchResultAsync(req, result);
+    }
+
+    [Function("DeleteDirection")]
+    [Authorize("Admin")]
+    [OpenApiOperation(operationId: "direction-delete", tags: new[] { "Direction" }, Summary = "Delete Direction", Description = "Deletes a direction", Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiParameter("directionId", In = ParameterLocation.Path, Required = true, Type = typeof(int), Description = "Direction ID")]
+    [OpenApiResponseWithoutBody(HttpStatusCode.OK, Summary = "Direction Deleted")]
+    public async Task<HttpResponseData> DeleteDirection(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "direction-delete/{directionId:int}")] HttpRequestData req,
+        int directionId)
+    {
+        var result = await _directionBusiness.DeleteAsync(directionId);
+        return await MatchResultAsync(req, result);
+    }
+
+    [Function("GetDirectionReport")]
+    [Authorize("Admin")]
+    [OpenApiOperation(operationId: "direction-report", tags: new[] { "Direction" }, Summary = "Get Direction Report", Description = "Returns paginated list of Directions", Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<DirectionReportFilterRequestDto>), Required = true)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(PagedReportResponseDto<DirectionReportDto>), Summary = "Direction Report")]
+    public async Task<HttpResponseData> GetDirectionReport(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "direction-report")] HttpRequestData req)
+    {
+        var filter = await req.ReadFromJsonAsync<PagedReportRequestDto<DirectionReportFilterRequestDto>>();
+        var result = await _directionBusiness.GetReportAsync(filter);
+        return await MatchResultAsync(req, result);
+    }
+}

--- a/transport.application/CityBusiness/CityBusiness.cs
+++ b/transport.application/CityBusiness/CityBusiness.cs
@@ -6,8 +6,8 @@ using Transport.Domain.Cities;
 using Transport.Domain.Cities.Abstraction;
 using Transport.SharedKernel;
 using Transport.SharedKernel.Contracts.City;
-using Transport.Domain;
 using Transport.Domain.Vehicles;
+using Transport.Domain.Directions;
 
 namespace Transport.Business.CityBusiness;
 

--- a/transport.application/Data/IApplicationDbContext.cs
+++ b/transport.application/Data/IApplicationDbContext.cs
@@ -8,6 +8,7 @@ using Transport.Domain.Vehicles;
 using Transport.Domain.Cities;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Transport.Domain.Services;
+using Transport.Domain.Directions;
 
 namespace Transport.Business.Data;
 

--- a/transport.application/DependencyInjection.cs
+++ b/transport.application/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Transport.Domain.Cities.Abstraction;
 using Transport.Domain.Services.Abstraction;
 using Transport.Domain.Customers.Abstraction;
 using Transport.Domain.Reserves.Abstraction;
+using Transport.Domain.Directions.Abstraction;
 
 namespace Transport.Business;
 
@@ -24,7 +25,7 @@ public static class DependencyInjection
         services.AddScoped<IServiceBusiness, ServiceBusiness.ServiceBusiness>();
         services.AddScoped<ICustomerBusiness, CustomerBusiness.CustomerBusiness>();
         services.AddScoped<IReserveBusiness, ReserveBusiness.ReserveBusiness>();
-
+        services.AddScoped<IDirectionBusiness, DirectionBusiness.DirectionBusiness>();
 
         return services;
     }

--- a/transport.application/DirectionBusiness/DirectionBusiness.cs
+++ b/transport.application/DirectionBusiness/DirectionBusiness.cs
@@ -1,0 +1,103 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Transport.Business.Data;
+using Transport.Domain;
+using Transport.Domain.Directions;
+using Transport.Domain.Directions.Abstraction;
+using Transport.SharedKernel;
+using Transport.SharedKernel.Contracts.Direction;
+
+namespace Transport.Business.DirectionBusiness;
+
+public class DirectionBusiness : IDirectionBusiness
+{
+    private readonly IApplicationDbContext _context;
+
+    public DirectionBusiness(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Result<int>> CreateAsync(DirectionCreateDto dto)
+    {
+        var direction = new Direction
+        {
+            Name = dto.Name,
+            Lat = dto.Lat,
+            Lng = dto.Lng,
+            CityId = dto.CityId
+        };
+
+        _context.Directions.Add(direction);
+        await _context.SaveChangesWithOutboxAsync();
+        return direction.DirectionId;
+    }
+
+    public async Task<Result<bool>> UpdateAsync(int directionId, DirectionUpdateDto dto)
+    {
+        var direction = await _context.Directions.FindAsync(directionId);
+        if (direction == null) return Result.Failure<bool>(DirectionError.DirectionNotFound);
+
+        direction.Name = dto.Name;
+        direction.Lat = dto.Lat;
+        direction.Lng = dto.Lng;
+        direction.CityId = dto.CityId;
+
+        _context.Directions.Update(direction);
+        await _context.SaveChangesWithOutboxAsync();
+        return true;
+    }
+
+    public async Task<Result<bool>> DeleteAsync(int directionId)
+    {
+        var direction = await _context.Directions.FindAsync(directionId);
+        if (direction == null) return Result.Failure<bool>(DirectionError.DirectionNotFound);
+
+        direction.Status = SharedKernel.EntityStatusEnum.Deleted;
+        _context.Directions.Update(direction);
+        await _context.SaveChangesWithOutboxAsync();
+        return true;
+    }
+
+    public async Task<Result<PagedReportResponseDto<DirectionReportDto>>> GetReportAsync(PagedReportRequestDto<DirectionReportFilterRequestDto> requestDto)
+    {
+        var query = _context.Directions
+             .AsNoTracking()
+             .Include(d => d.City)
+             .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(requestDto.Filters?.DirectionName))
+        {
+            query = query.Where(d => d.Name.Contains(requestDto.Filters.DirectionName));
+        }
+
+        if (requestDto.Filters?.CityId is not null)
+        {
+            query = query.Where(d => d.CityId == requestDto.Filters.CityId.Value);
+        }
+
+        var sortMappings = new Dictionary<string, Expression<Func<Direction, object>>>
+        {
+            ["name"] = d => d.Name,
+            ["cityName"] = d => d.City.Name,
+            ["createdDate"] = d => d.CreatedDate
+        };
+
+        var pagedResult = await query.ToPagedReportAsync<DirectionReportDto, Direction, DirectionReportFilterRequestDto>(
+            requestDto,
+            selector: d => new DirectionReportDto(
+                d.DirectionId,
+                d.Name,
+                d.Lat,
+                d.Lng,
+                d.CityId,
+                d.City.Name,
+                d.CreatedDate,
+                d.UpdatedDate
+            ),
+            sortMappings: sortMappings
+        );
+
+        return Result.Success(pagedResult);
+    }
+}

--- a/transport.application/DirectionBusiness/Validation/DirectionCreateValidator.cs
+++ b/transport.application/DirectionBusiness/Validation/DirectionCreateValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using Transport.SharedKernel.Contracts.Direction;
+
+namespace Transport.Business.DirectionBusiness.Validation;
+
+public class DirectionCreateValidator : AbstractValidator<DirectionCreateDto>
+{
+    public DirectionCreateValidator()
+    {
+        RuleFor(x => x.Name)
+                    .NotEmpty().WithMessage("El nombre es obligatorio.")
+                    .MaximumLength(150).WithMessage("El nombre no puede superar los 150 caracteres.");
+
+        RuleFor(x => x.CityId)
+            .GreaterThan(0).WithMessage("El CityId debe ser mayor a 0.");
+    }
+}

--- a/transport.application/DirectionBusiness/Validation/DirectionUpdateValidator.cs
+++ b/transport.application/DirectionBusiness/Validation/DirectionUpdateValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+using Transport.SharedKernel.Contracts.Direction;
+
+namespace Transport.Business.DirectionBusiness.Validation;
+
+public class DirectionUpdateValidator: AbstractValidator<DirectionUpdateDto>
+{
+    public DirectionUpdateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("El nombre es obligatorio.")
+            .MaximumLength(150).WithMessage("El nombre no puede superar los 150 caracteres.");
+
+        RuleFor(x => x.CityId)
+            .GreaterThan(0).WithMessage("El CityId debe ser mayor a 0.");
+
+    }
+}

--- a/transport.common/Contracts/Direction/DirectionCreateDto.cs
+++ b/transport.common/Contracts/Direction/DirectionCreateDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Transport.SharedKernel.Contracts.Direction;
+
+public record DirectionCreateDto(
+  string Name,
+  double? Lat,
+  double? Lng,
+  int CityId
+);

--- a/transport.common/Contracts/Direction/DirectionReportDto.cs
+++ b/transport.common/Contracts/Direction/DirectionReportDto.cs
@@ -1,0 +1,12 @@
+﻿namespace Transport.SharedKernel.Contracts.Direction;
+
+public record DirectionReportDto(
+    int DirectionId,
+    string Name,
+    double? Lat,
+    double? Lng,
+    int CityId,
+    string CityName,
+    DateTime CreatedDate,
+    DateTime? UpdatedDate
+);

--- a/transport.common/Contracts/Direction/DirectionReportFilterRequestDto.cs
+++ b/transport.common/Contracts/Direction/DirectionReportFilterRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Transport.SharedKernel.Contracts.Direction;
+
+public record DirectionReportFilterRequestDto(string DirectionName, int? CityId);

--- a/transport.common/Contracts/Direction/DirectionUpdateDto.cs
+++ b/transport.common/Contracts/Direction/DirectionUpdateDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Transport.SharedKernel.Contracts.Direction;
+
+public record DirectionUpdateDto(
+    string Name,
+    double? Lat,
+    double? Lng,
+    int CityId
+);

--- a/transport.domain/Cities/City.cs
+++ b/transport.domain/Cities/City.cs
@@ -1,4 +1,5 @@
-﻿using Transport.Domain.Services;
+﻿using Transport.Domain.Directions;
+using Transport.Domain.Services;
 using Transport.SharedKernel;
 
 namespace Transport.Domain.Cities;

--- a/transport.domain/Customers/CustomerReserve.cs
+++ b/transport.domain/Customers/CustomerReserve.cs
@@ -1,4 +1,5 @@
-﻿using Transport.Domain.Reserves;
+﻿using Transport.Domain.Directions;
+using Transport.Domain.Reserves;
 using Transport.SharedKernel;
 
 namespace Transport.Domain.Customers;

--- a/transport.domain/Directions/Abstraction/IDirectionBusiness.cs
+++ b/transport.domain/Directions/Abstraction/IDirectionBusiness.cs
@@ -1,0 +1,12 @@
+﻿using Transport.SharedKernel;
+using Transport.SharedKernel.Contracts.Direction;
+
+namespace Transport.Domain.Directions.Abstraction;
+
+public interface IDirectionBusiness
+{
+    Task<Result<int>> CreateAsync(DirectionCreateDto dto);
+    Task<Result<bool>> UpdateAsync(int directionId, DirectionUpdateDto dto);
+    Task<Result<bool>> DeleteAsync(int directionId);
+    Task<Result<PagedReportResponseDto<DirectionReportDto>>> GetReportAsync(PagedReportRequestDto<DirectionReportFilterRequestDto> requestDto);
+}

--- a/transport.domain/Directions/Direction.cs
+++ b/transport.domain/Directions/Direction.cs
@@ -2,7 +2,7 @@
 using Transport.Domain.Customers;
 using Transport.SharedKernel;
 
-namespace Transport.Domain;
+namespace Transport.Domain.Directions;
 
 public class Direction: IAuditable
 {
@@ -11,6 +11,7 @@ public class Direction: IAuditable
     public double? Lat { get; set; }
     public double? Lng { get; set; }
     public int CityId { get; set; }
+    public EntityStatusEnum Status { get; set; }
 
     public string CreatedBy { get; set; } = null!;
     public string? UpdatedBy { get; set; }

--- a/transport.domain/Directions/DirectionError.cs
+++ b/transport.domain/Directions/DirectionError.cs
@@ -1,0 +1,10 @@
+﻿using Transport.SharedKernel;
+
+namespace Transport.Domain.Directions;
+
+public static class DirectionError
+{
+    public static readonly Error DirectionNotFound = Error.Validation(
+       "Direction.DirectionId",
+       "La Dirección no existe");
+}

--- a/transport.infraestructure/Database/ApplicationDbContext.cs
+++ b/transport.infraestructure/Database/ApplicationDbContext.cs
@@ -11,6 +11,7 @@ using Transport.Domain.Cities;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Transport.Domain.Services;
 using Transport.Business.Authentication;
+using Transport.Domain.Directions;
 
 namespace Transport.Infraestructure.Database;
 

--- a/transport.infraestructure/Database/EntityTypesConfigurations/DirectionConfiguration.cs
+++ b/transport.infraestructure/Database/EntityTypesConfigurations/DirectionConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
-using Transport.Domain;
+using Transport.Domain.Directions;
 
 namespace Transport.Infraestructure.Database.EntityTypesConfigurations;
 
@@ -9,8 +9,10 @@ public class DirectionConfiguration : IEntityTypeConfiguration<Direction>
     public void Configure(EntityTypeBuilder<Direction> builder)
     {
         builder.ToTable("Direction");
+
         builder.HasKey(d => d.DirectionId);
-        builder.Property(d => d.Name).HasMaxLength(250).IsRequired();
+
+        builder.Property(d => d.Name).HasColumnType("VARCHAR(250)").IsRequired();
 
         builder.HasOne(d => d.City)
                .WithMany(c => c.Directions)

--- a/transport.infraestructure/Migrations/20250526113343_AddStatusInDirection.Designer.cs
+++ b/transport.infraestructure/Migrations/20250526113343_AddStatusInDirection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Transport.Infraestructure.Database;
 
@@ -11,9 +12,11 @@ using Transport.Infraestructure.Database;
 namespace Transport.Infraestructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250526113343_AddStatusInDirection")]
+    partial class AddStatusInDirection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/transport.infraestructure/Migrations/20250526113343_AddStatusInDirection.cs
+++ b/transport.infraestructure/Migrations/20250526113343_AddStatusInDirection.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transport.Infraestructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStatusInDirection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Direction",
+                type: "VARCHAR(250)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Direction",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 26, 11, 33, 42, 541, DateTimeKind.Utc).AddTicks(5717));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 26, 11, 33, 42, 541, DateTimeKind.Utc).AddTicks(5719));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Direction");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Direction",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "VARCHAR(250)");
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 24, 19, 17, 50, 567, DateTimeKind.Utc).AddTicks(852));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 24, 19, 17, 50, 567, DateTimeKind.Utc).AddTicks(855));
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new `Direction` feature in the Transport application, including the `Direction` entity, associated business logic, data transfer objects (DTOs), and validation classes.

Key changes include:
- Replacement of `DateTime.Today` with `_dateTimeProviderMock.Object.UtcNow` in tests for improved reliability.
- Implementation of the `DirectionBusiness` class for managing direction operations.
- Creation of HTTP endpoints in the `DirectionFunction` class with OpenAPI documentation.
- Database migrations to add the `Direction` table and a `Status` column.
- Addition of unit tests for the `DirectionBusiness` class to ensure functionality.