### PR TITLE
Añadir columnas a CustomerReserve y actualizar lógica

### DIFF
--- a/idempotent.sql
+++ b/idempotent.sql
@@ -738,3 +738,61 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [CustomerEmail] VARCHAR(150) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [CustomerFullName] VARCHAR(250) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [DestinationCityName] VARCHAR(100) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [DocumentNumber] VARCHAR(50) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [DriverName] VARCHAR(100) NULL;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [DropoffAddress] VARCHAR(250) NULL;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [OriginCityName] VARCHAR(100) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [Phone1] VARCHAR(30) NULL;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [Phone2] VARCHAR(30) NULL;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [PickupAddress] VARCHAR(250) NULL;
+GO
+
+ALTER TABLE [CustomerReserve] ADD [ServiceName] VARCHAR(250) NOT NULL DEFAULT '';
+GO
+
+ALTER TABLE [CustomerReserve] ADD [VehicleInternalNumber] VARCHAR(20) NOT NULL DEFAULT '';
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-06-01T20:42:32.3185202Z'
+WHERE [RoleId] = 1;
+SELECT @@ROWCOUNT;
+
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-06-01T20:42:32.3185206Z'
+WHERE [RoleId] = 2;
+SELECT @@ROWCOUNT;
+
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250601204232_DesnormalizarCustomerReserveParaReportes', N'8.0.14');
+GO
+
+COMMIT;
+GO
+

--- a/transport.domain/Customers/CustomerReserve.cs
+++ b/transport.domain/Customers/CustomerReserve.cs
@@ -27,4 +27,18 @@ public class CustomerReserve: IAuditable
     public Reserve Reserve { get; set; } = null!;
     public Direction PickupLocation { get; set; } = null!;
     public Direction DropoffLocation { get; set; } = null!;
+
+    public string ServiceName { get; set; } = null!;
+    public string OriginCityName { get; set; } = null!;
+    public string DestinationCityName { get; set; } = null!;
+    public string VehicleInternalNumber { get; set; } = null!;
+    public string? DriverName { get; set; }
+    public string? PickupAddress { get; set; }
+    public string? DropoffAddress { get; set; }
+    public string CustomerFullName { get; set; } = null!;
+    public string DocumentNumber { get; set; } = null!;
+    public string CustomerEmail { get; set; } = null!;
+    public string? Phone1 { get; set; }
+    public string? Phone2 { get; set; }
+
 }

--- a/transport.domain/Reserves/ReserveError.cs
+++ b/transport.domain/Reserves/ReserveError.cs
@@ -16,6 +16,12 @@ public static class ReserveError
         "Reserve.PriceNotAvailable",
         "No se encontró un precio válido para el tipo de reserva.");
 
+    public static Error VehicleQuantityNotAvailable(int existing, int incoming, int capacity) =>
+      Error.Problem(
+          "Reserve.VehicleNotAvailable",
+          $"No hay suficientes asientos disponibles. Ya reservados: {existing}, nuevos: {incoming}, capacidad: {capacity}."
+      );
+
     public static Error CustomerAlreadyExists(string documentNumber) =>
         Error.Validation(
             "Reserve.CustomerAlreadyExists",

--- a/transport.infraestructure/Database/EntityTypesConfigurations/CustomerReserveConfiguration.cs
+++ b/transport.infraestructure/Database/EntityTypesConfigurations/CustomerReserveConfiguration.cs
@@ -39,5 +39,65 @@ public class CustomerReserveConfiguration : IEntityTypeConfiguration<CustomerRes
                .HasConversion<string>()
                .HasColumnType("VARCHAR(20)")
                .IsRequired(false);
+
+        builder.Property(cr => cr.ServiceName)
+                .HasMaxLength(250)
+                .HasColumnType("VARCHAR(250)")
+                .IsRequired();
+
+        builder.Property(cr => cr.OriginCityName)
+            .HasMaxLength(100)
+            .HasColumnType("VARCHAR(100)")
+            .IsRequired();
+
+        builder.Property(cr => cr.DestinationCityName)
+            .HasMaxLength(100)
+            .HasColumnType("VARCHAR(100)")
+            .IsRequired();
+
+        builder.Property(cr => cr.VehicleInternalNumber)
+            .HasMaxLength(20)
+            .HasColumnType("VARCHAR(20)")
+            .IsRequired();
+
+        builder.Property(cr => cr.DriverName)
+            .HasMaxLength(100)
+            .HasColumnType("VARCHAR(100)")
+            .IsRequired(false);
+
+        builder.Property(cr => cr.PickupAddress)
+            .HasMaxLength(250)
+            .HasColumnType("VARCHAR(250)")
+            .IsRequired(false);
+
+        builder.Property(cr => cr.DropoffAddress)
+            .HasMaxLength(250)
+            .HasColumnType("VARCHAR(250)")
+            .IsRequired(false);
+
+        builder.Property(cr => cr.CustomerFullName)
+            .HasMaxLength(250)
+            .HasColumnType("VARCHAR(250)")
+            .IsRequired();
+
+        builder.Property(cr => cr.DocumentNumber)
+            .HasMaxLength(50)
+            .HasColumnType("VARCHAR(50)")
+            .IsRequired();
+
+        builder.Property(cr => cr.CustomerEmail)
+            .HasMaxLength(150)
+            .HasColumnType("VARCHAR(150)")
+            .IsRequired();
+
+        builder.Property(cr => cr.Phone1)
+            .HasMaxLength(30)
+            .HasColumnType("VARCHAR(30)")
+            .IsRequired(false);
+
+        builder.Property(cr => cr.Phone2)
+            .HasMaxLength(30)
+            .HasColumnType("VARCHAR(30)")
+            .IsRequired(false);
     }
 }

--- a/transport.infraestructure/Migrations/20250601204232_DesnormalizarCustomerReserveParaReportes.Designer.cs
+++ b/transport.infraestructure/Migrations/20250601204232_DesnormalizarCustomerReserveParaReportes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Transport.Infraestructure.Database;
 
@@ -11,9 +12,11 @@ using Transport.Infraestructure.Database;
 namespace Transport.Infraestructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250601204232_DesnormalizarCustomerReserveParaReportes")]
+    partial class DesnormalizarCustomerReserveParaReportes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/transport.infraestructure/Migrations/20250601204232_DesnormalizarCustomerReserveParaReportes.cs
+++ b/transport.infraestructure/Migrations/20250601204232_DesnormalizarCustomerReserveParaReportes.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transport.Infraestructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DesnormalizarCustomerReserveParaReportes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerEmail",
+                table: "CustomerReserve",
+                type: "VARCHAR(150)",
+                maxLength: 150,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerFullName",
+                table: "CustomerReserve",
+                type: "VARCHAR(250)",
+                maxLength: 250,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DestinationCityName",
+                table: "CustomerReserve",
+                type: "VARCHAR(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentNumber",
+                table: "CustomerReserve",
+                type: "VARCHAR(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DriverName",
+                table: "CustomerReserve",
+                type: "VARCHAR(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DropoffAddress",
+                table: "CustomerReserve",
+                type: "VARCHAR(250)",
+                maxLength: 250,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OriginCityName",
+                table: "CustomerReserve",
+                type: "VARCHAR(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Phone1",
+                table: "CustomerReserve",
+                type: "VARCHAR(30)",
+                maxLength: 30,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Phone2",
+                table: "CustomerReserve",
+                type: "VARCHAR(30)",
+                maxLength: 30,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PickupAddress",
+                table: "CustomerReserve",
+                type: "VARCHAR(250)",
+                maxLength: 250,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ServiceName",
+                table: "CustomerReserve",
+                type: "VARCHAR(250)",
+                maxLength: 250,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "VehicleInternalNumber",
+                table: "CustomerReserve",
+                type: "VARCHAR(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 1, 20, 42, 32, 318, DateTimeKind.Utc).AddTicks(5202));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 1, 20, 42, 32, 318, DateTimeKind.Utc).AddTicks(5206));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CustomerEmail",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "CustomerFullName",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "DestinationCityName",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentNumber",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "DriverName",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "DropoffAddress",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "OriginCityName",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "Phone1",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "Phone2",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "PickupAddress",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "ServiceName",
+                table: "CustomerReserve");
+
+            migrationBuilder.DropColumn(
+                name: "VehicleInternalNumber",
+                table: "CustomerReserve");
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 30, 1, 26, 3, 410, DateTimeKind.Utc).AddTicks(1367));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 5, 30, 1, 26, 3, 410, DateTimeKind.Utc).AddTicks(1370));
+        }
+    }
+}


### PR DESCRIPTION
Se han añadido varias columnas a la tabla `CustomerReserve`, incluyendo `CustomerEmail`, `CustomerFullName`, `DestinationCityName`, `DocumentNumber`, `DriverName`, `DropoffAddress`, `OriginCityName`, `Phone1`, `Phone2`, `PickupAddress`, `ServiceName` y `VehicleInternalNumber`, con sus respectivas configuraciones.

Se han actualizado las fechas de creación en la tabla `Role` y se han realizado cambios en la clase `ReserveBusiness` para manejar la nueva lógica relacionada con `CustomerReserve`. Además, se han añadido métodos auxiliares para la obtención de direcciones y la gestión de clientes.

Las configuraciones de `CustomerReserve` en `CustomerReserveConfiguration` se han actualizado para incluir las nuevas propiedades. También se han realizado cambios en la migración `20250601204232_DesnormalizarCustomerReserveParaReportes` y se han actualizado los archivos de `ApplicationDbContextModelSnapshot` para reflejar la nueva estructura del modelo de datos.