### PR TITLE
Cambiado método GetCustomerReserveReport a POST

### DIFF
--- a/transport.api/Functions/ReservesFunction.cs
+++ b/transport.api/Functions/ReservesFunction.cs
@@ -89,7 +89,7 @@ public class ReservesFunction : FunctionBase
     [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<CustomerReserveReportFilterRequestDto>), Required = true)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(PagedReportResponseDto<CustomerReserveReportResponseDto>), Summary = "Customer Reserve Report")]
     public async Task<HttpResponseData> GetCustomerReserveReport(
-    [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "customer-reserve-report/{reserveId:int}")] HttpRequestData req,
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "customer-reserve-report/{reserveId:int}")] HttpRequestData req,
     int reserveId)
     {
         var filter = await req.ReadFromJsonAsync<PagedReportRequestDto<CustomerReserveReportFilterRequestDto>>();


### PR DESCRIPTION
Se ha modificado el método `GetCustomerReserveReport` para utilizar el método HTTP `POST` en lugar de `GET`. La ruta del endpoint se mantiene como `customer-reserve-report/{reserveId:int}`.