### PR TITLE
Añadir soporte para precios de reserva en informes

### DIFF
--- a/transport.application/ReserveBusiness/ReserveBusiness.cs
+++ b/transport.application/ReserveBusiness/ReserveBusiness.cs
@@ -10,6 +10,7 @@ using Transport.Domain.Vehicles;
 using Transport.SharedKernel;
 using Transport.SharedKernel.Contracts.Customer;
 using Transport.SharedKernel.Contracts.Reserve;
+using Transport.SharedKernel.Contracts.Service;
 
 namespace Transport.Business.ReserveBusiness;
 
@@ -239,10 +240,7 @@ public class ReserveBusiness : IReserveBusiness
     public async Task<Result<PagedReportResponseDto<ReserveReportResponseDto>>> GetReserveReport(DateTime reserveDate,
     PagedReportRequestDto<ReserveReportFilterRequestDto> requestDto)
     {
-        var query = _context.Reserves
-            .Include(rp => rp.Service).ThenInclude(s => s.Vehicle)
-            .Include(rp => rp.CustomerReserves)
-            .Where(rp => rp.Status == ReserveStatusEnum.Confirmed);
+        var query = _context.Reserves.Where(rp => rp.Status == ReserveStatusEnum.Confirmed);
 
         var date = reserveDate.Date;
         query = query.Where(rp => rp.ReserveDate.Date == date);
@@ -274,7 +272,8 @@ public class ReserveBusiness : IReserveBusiness
                       p.ReserveId,
                       p.DropoffLocationId!.Value,
                       p.PickupLocationId!.Value))
-                  .ToList()
+                  .ToList(),
+                rp.Service.ReservePrices.Select(p => new ReservePriceReport((int)p.ReserveTypeId, p.Price)).ToList()
             ),
             sortMappings: sortMappings
         );

--- a/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Transport.SharedKernel.Contracts.Reserve;
+﻿using Transport.SharedKernel.Contracts.Service;
+
+namespace Transport.SharedKernel.Contracts.Reserve;
 
 public record ReserveReportResponseDto(int ReserveId, 
     string OriginName, 
@@ -6,4 +8,5 @@ public record ReserveReportResponseDto(int ReserveId,
     int AvailableQuantity,
     int ReservedQuantity,
     string DepartureHour,
-    List<CustomerReserveReportResponseDto> Passengers);
+    List<CustomerReserveReportResponseDto> Passengers,
+    List<ReservePriceReport> Prices);


### PR DESCRIPTION
Se ha añadido la directiva `using Transport.SharedKernel.Contracts.Service;` en `ReserveBusiness.cs` para incluir el contrato de servicio.

Se ha simplificado la consulta en el método `GetReserveReport`, eliminando las inclusiones de `Service` y `CustomerReserves`, y filtrando solo las reservas confirmadas por fecha.

Se ha añadido la propiedad `Prices` en `ReserveReportResponseDto` para incluir información sobre los precios de las reservas.

Además, se ha reordenado el espacio de nombres en `ReserveReportResponseDto.cs` para reflejar el uso de la nueva directiva.