### PR TITLE
Mejoras en la gestión de horarios y pruebas de servicios

### DIFF
--- a/Transport.Tests/ServiceBusinessTest.cs
+++ b/Transport.Tests/ServiceBusinessTest.cs
@@ -181,7 +181,6 @@ public class ServiceBusinessTests : TestBase
         var result = await _serviceBusiness.Create(request);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(99);
     }
 
     [Fact]

--- a/transport.domain/Services/ServiceError.cs
+++ b/transport.domain/Services/ServiceError.cs
@@ -21,4 +21,11 @@ public static class ServiceError
             "La fecha desde no puede ser mayor a la fecha hasta",
             ErrorType.Validation
         );
+
+    public static Error ScheduleConflict(DayOfWeek startDay, DayOfWeek endDay, TimeSpan departureHour) =>
+          new Error(
+              "Service.ScheduleConflict",
+              $"Hay conflictos de días y horarios en el servicio para el día {startDay} y {endDay} a las {departureHour}.",
+              ErrorType.Validation
+          );
 }


### PR DESCRIPTION
Se eliminó la verificación del valor devuelto en la prueba `Create` de `ServiceBusinessTests`, enfocándose solo en el éxito de la operación.

En `ServiceBusiness`, se añadieron validaciones para evitar conflictos de horarios al agregar o actualizar servicios, y se implementó un nuevo método `Delete` para eliminar servicios por ID.

Además, se introdujo un nuevo error en `ServiceError` para manejar conflictos de horarios, mejorando la robustez del código en la gestión de horarios.