### PR TITLE
Añadir propiedades VehicleId y DriverId a reservas

### DIFF
--- a/transport.application/ReserveBusiness/ReserveBusiness.cs
+++ b/transport.application/ReserveBusiness/ReserveBusiness.cs
@@ -261,6 +261,8 @@ public class ReserveBusiness : IReserveBusiness
                 rp.Service.Vehicle.AvailableQuantity,
                 rp.CustomerReserves.Count,
                 rp.DepartureHour.ToString(@"hh\:mm"),
+                rp.VehicleId,
+                rp.DriverId.GetValueOrDefault(),
                 rp.CustomerReserves
                   .Select(p => new CustomerReserveReportResponseDto(
                       p.CustomerReserveId,

--- a/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveReportResponseDto.cs
@@ -8,5 +8,7 @@ public record ReserveReportResponseDto(int ReserveId,
     int AvailableQuantity,
     int ReservedQuantity,
     string DepartureHour,
+    int VehicleId, 
+    int DriverId,
     List<CustomerReserveReportResponseDto> Passengers,
     List<ReservePriceReport> Prices);


### PR DESCRIPTION
Se han añadido las propiedades `VehicleId` y `DriverId` a la clase `ReserveBusiness` y al registro `ReserveReportResponseDto`. Esto permite almacenar información adicional sobre el vehículo y el conductor asociados a una reserva.