### PR TITLE
Añadir lógica y pruebas para creación de pagos de reserva

### DIFF
--- a/transport.common/Contracts/Reserve/ReservePriceReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReservePriceReportResponseDto.cs
@@ -5,3 +5,9 @@ public record ReservePriceReportResponseDto(int ReservePriceId,
     string ServiceName,
     decimal Price,
     int ReserveTypeId);
+
+public record ReservePaymentReportResponseDto(int ReservePaymentId,
+    int ReserveId,
+    int CustomerId,
+    decimal TransactionAmount,
+    int PaymentMethod);

--- a/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
+++ b/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
@@ -17,4 +17,8 @@ public interface IReserveBusiness
     Task<Result<PagedReportResponseDto<CustomerReserveReportResponseDto>>> GetReserveCustomerReport(int reserveId, PagedReportRequestDto<CustomerReserveReportFilterRequestDto> requestDto);
 
     Task<Result<bool>> UpdateReserveAsync(int reserveId, ReserveUpdateRequestDto request);
+    Task<Result<bool>> CreatePaymentsAsync(
+    int reserveId,
+    int customerId,
+    List<CreatePaymentRequestDto> payments);
 }


### PR DESCRIPTION
Se han implementado pruebas unitarias en `ReserveBusinessTests.cs` para el método `CreatePaymentsAsync`, cubriendo varios escenarios de fallo y éxito.

Se ha añadido un nuevo método `CreateReservePayments` en `ReservesFunction.cs` que actúa como endpoint para crear pagos, validando la entrada y llamando al método correspondiente en el negocio de reservas.

El método `CreatePaymentsAsync` en `ReserveBusiness.cs` ahora maneja la lógica de creación de pagos, incluyendo validaciones de reserva, cliente, montos válidos y métodos de pago duplicados.

Además, se ha introducido el DTO `ReservePaymentReportResponseDto` en `ReservePriceReportResponseDto.cs` y se ha actualizado la interfaz `IReserveBusiness` para incluir el nuevo método de creación de pagos.