### PR TITLE
Añadir gestión de saldo y transacciones de clientes

### DIFF
--- a/idempotent.sql
+++ b/idempotent.sql
@@ -904,3 +904,63 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+ALTER TABLE [Customer] ADD [CurrentBalance] decimal(18,2) NOT NULL DEFAULT 0.0;
+GO
+
+CREATE TABLE [CustomerAccountTransactions] (
+    [CustomerAccountTransactionId] int NOT NULL IDENTITY,
+    [CustomerId] int NOT NULL,
+    [Date] datetime2 NOT NULL,
+    [Type] nvarchar(20) NOT NULL,
+    [Amount] decimal(18,2) NOT NULL,
+    [Description] nvarchar(250) NULL,
+    [RelatedReserveId] int NULL,
+    [ReservePaymentId] int NULL,
+    [CreatedBy] VARCHAR(256) NOT NULL DEFAULT 'System',
+    [UpdatedBy] VARCHAR(256) NULL,
+    [CreatedDate] datetime2 NOT NULL DEFAULT (GETDATE()),
+    [UpdatedDate] datetime2 NULL,
+    CONSTRAINT [PK_CustomerAccountTransactions] PRIMARY KEY ([CustomerAccountTransactionId]),
+    CONSTRAINT [FK_CustomerAccountTransactions_Customer_CustomerId] FOREIGN KEY ([CustomerId]) REFERENCES [Customer] ([CustomerId]) ON DELETE CASCADE,
+    CONSTRAINT [FK_CustomerAccountTransactions_ReservePayment_ReservePaymentId] FOREIGN KEY ([ReservePaymentId]) REFERENCES [ReservePayment] ([ReservePaymentId]) ON DELETE NO ACTION,
+    CONSTRAINT [FK_CustomerAccountTransactions_Reserve_RelatedReserveId] FOREIGN KEY ([RelatedReserveId]) REFERENCES [Reserve] ([ReserveId]) ON DELETE SET NULL
+);
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-06-27T22:28:21.0110427Z'
+WHERE [RoleId] = 1;
+SELECT @@ROWCOUNT;
+
+GO
+
+UPDATE [Role] SET [CreatedDate] = '2025-06-27T22:28:21.0110429Z'
+WHERE [RoleId] = 2;
+SELECT @@ROWCOUNT;
+
+GO
+
+CREATE INDEX [IX_CustomerAccountTransactions_CustomerId] ON [CustomerAccountTransactions] ([CustomerId]);
+GO
+
+CREATE INDEX [IX_CustomerAccountTransactions_Date] ON [CustomerAccountTransactions] ([Date]);
+GO
+
+CREATE INDEX [IX_CustomerAccountTransactions_RelatedReserveId] ON [CustomerAccountTransactions] ([RelatedReserveId]);
+GO
+
+CREATE INDEX [IX_CustomerAccountTransactions_ReservePaymentId] ON [CustomerAccountTransactions] ([ReservePaymentId]);
+GO
+
+CREATE INDEX [IX_CustomerAccountTransactions_Type] ON [CustomerAccountTransactions] ([Type]);
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'20250627222821_AddCtaCte', N'8.0.14');
+GO
+
+COMMIT;
+GO
+

--- a/transport.application/Data/IApplicationDbContext.cs
+++ b/transport.application/Data/IApplicationDbContext.cs
@@ -29,5 +29,6 @@ public interface IApplicationDbContext
     DbSet<CustomerReserve> CustomerReserves { get; }
     DbSet<ServiceSchedule> ServiceSchedules { get; }
     DbSet<ReservePayment> ReservePayments { get; }
+    DbSet<CustomerAccountTransaction> CustomerAccountTransactions { get; }
     Task<int> SaveChangesWithOutboxAsync(CancellationToken cancellationToken = default);
 }

--- a/transport.common/Contracts/Reserve/CustomerReserveReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/CustomerReserveReportResponseDto.cs
@@ -9,4 +9,6 @@ public record CustomerReserveReportResponseDto(
     string FullPhone,
     int ReserveId,
     int DropoffLocationId,
-    int PickupLocationId);
+    string? DropoffLocationName,
+    int PickupLocationId,
+    string? PickupLocationName);

--- a/transport.domain/Customers/Customer.cs
+++ b/transport.domain/Customers/Customer.cs
@@ -4,7 +4,7 @@ using Transport.SharedKernel;
 
 namespace Transport.Domain.Customers;
 
-public class Customer: Entity, IAuditable
+public class Customer : Entity, IAuditable
 {
     public int CustomerId { get; set; }
     public string FirstName { get; set; } = null!;
@@ -15,6 +15,7 @@ public class Customer: Entity, IAuditable
     public string? Phone2 { get; set; }
     public EntityStatusEnum Status { get; set; } = EntityStatusEnum.Active;
     public User? User { get; set; }
+    public decimal CurrentBalance { get; set; }
 
     public string CreatedBy { get; set; } = null!;
     public string? UpdatedBy { get; set; }
@@ -23,4 +24,5 @@ public class Customer: Entity, IAuditable
 
     public ICollection<ServiceCustomer> Services { get; set; } = new List<ServiceCustomer>();
     public ICollection<CustomerReserve> CustomerReserves { get; set; } = new List<CustomerReserve>();
+    public ICollection<CustomerAccountTransaction> AccountTransactions { get; set; } = new List<CustomerAccountTransaction>();
 }

--- a/transport.domain/Customers/CustomerAccountTransaction.cs
+++ b/transport.domain/Customers/CustomerAccountTransaction.cs
@@ -1,0 +1,42 @@
+﻿using Transport.Domain.Reserves;
+using Transport.SharedKernel;
+
+namespace Transport.Domain.Customers;
+
+public class CustomerAccountTransaction : Entity, IAuditable
+{
+    public int CustomerAccountTransactionId { get; set; }
+
+    public int CustomerId { get; set; }
+    public Customer Customer { get; set; } = null!;
+
+    public DateTime Date { get; set; } = DateTime.UtcNow;
+
+    // Puede ser "Charge", "Payment", "Adjustment", etc.
+    public TransactionType Type { get; set; }
+
+    public decimal Amount { get; set; }
+
+    public string? Description { get; set; }
+
+    public int? RelatedReserveId { get; set; }
+    public Reserve? RelatedReserve { get; set; }
+    public int? ReservePaymentId { get; set; }
+    public ReservePayment? ReservePayment { get; set; }
+
+    public string CreatedBy { get; set; } = null!;
+    public string? UpdatedBy { get; set; }
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedDate
+    {
+        get; set;
+    }
+}
+
+public enum TransactionType
+{
+    Charge,
+    Payment,
+    Adjustment,
+    Refund
+}

--- a/transport.infraestructure/Database/ApplicationDbContext.cs
+++ b/transport.infraestructure/Database/ApplicationDbContext.cs
@@ -37,7 +37,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<CustomerReserve> CustomerReserves { get; set; }
     public DbSet<ServiceSchedule> ServiceSchedules { get; set; }
     public DbSet<ReservePayment> ReservePayments { get; set; }
-
+    public DbSet<CustomerAccountTransaction> CustomerAccountTransactions { get; set; }
 
     private readonly IUserContext _userContext;
 

--- a/transport.infraestructure/Database/EntityTypesConfigurations/CustomerAccountTransactionConfiguration.cs
+++ b/transport.infraestructure/Database/EntityTypesConfigurations/CustomerAccountTransactionConfiguration.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore;
+using Transport.Domain.Customers;
+
+namespace Transport.Infraestructure.Database.EntityTypesConfigurations;
+
+public class CustomerAccountTransactionConfiguration : IEntityTypeConfiguration<CustomerAccountTransaction>
+{
+    public void Configure(EntityTypeBuilder<CustomerAccountTransaction> builder)
+    {
+        builder.ToTable("CustomerAccountTransactions");
+
+        builder.HasKey(t => t.CustomerAccountTransactionId);
+
+        builder.Property(t => t.Date)
+               .IsRequired();
+
+        builder.Property(t => t.Type)
+               .IsRequired()
+               .HasConversion<string>()
+               .HasMaxLength(20);
+
+        builder.Property(t => t.Amount)
+               .HasColumnType("decimal(18,2)")
+               .IsRequired();
+
+        builder.Property(t => t.Description)
+               .HasMaxLength(250);
+
+        builder.HasOne(t => t.Customer)
+               .WithMany(c => c.AccountTransactions)
+               .HasForeignKey(t => t.CustomerId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(t => t.RelatedReserve)
+               .WithMany()
+               .HasForeignKey(t => t.RelatedReserveId)
+               .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(x => x.ReservePayment)
+            .WithMany()
+            .HasForeignKey(x => x.ReservePaymentId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(t => t.Date);
+        builder.HasIndex(t => t.Type);
+    }
+}

--- a/transport.infraestructure/Database/EntityTypesConfigurations/CustomerConfiguration.cs
+++ b/transport.infraestructure/Database/EntityTypesConfigurations/CustomerConfiguration.cs
@@ -19,5 +19,9 @@ public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         builder.Property(c => c.Phone1).HasMaxLength(20).IsRequired();
         builder.Property(c => c.Phone2).HasMaxLength(20);
         builder.Property(r => r.Status).IsRequired();
+        builder.Property(r => r.CurrentBalance)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired()
+            .HasDefaultValue(0);
     }
 }

--- a/transport.infraestructure/Migrations/20250627222821_AddCtaCte.Designer.cs
+++ b/transport.infraestructure/Migrations/20250627222821_AddCtaCte.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Transport.Infraestructure.Database;
 
@@ -11,9 +12,11 @@ using Transport.Infraestructure.Database;
 namespace Transport.Infraestructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250627222821_AddCtaCte")]
+    partial class AddCtaCte
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/transport.infraestructure/Migrations/20250627222821_AddCtaCte.cs
+++ b/transport.infraestructure/Migrations/20250627222821_AddCtaCte.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transport.Infraestructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCtaCte : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "CurrentBalance",
+                table: "Customer",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.CreateTable(
+                name: "CustomerAccountTransactions",
+                columns: table => new
+                {
+                    CustomerAccountTransactionId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CustomerId = table.Column<int>(type: "int", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
+                    RelatedReserveId = table.Column<int>(type: "int", nullable: true),
+                    ReservePaymentId = table.Column<int>(type: "int", nullable: true),
+                    CreatedBy = table.Column<string>(type: "VARCHAR(256)", nullable: false, defaultValue: "System"),
+                    UpdatedBy = table.Column<string>(type: "VARCHAR(256)", nullable: true),
+                    CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETDATE()"),
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomerAccountTransactions", x => x.CustomerAccountTransactionId);
+                    table.ForeignKey(
+                        name: "FK_CustomerAccountTransactions_Customer_CustomerId",
+                        column: x => x.CustomerId,
+                        principalTable: "Customer",
+                        principalColumn: "CustomerId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CustomerAccountTransactions_ReservePayment_ReservePaymentId",
+                        column: x => x.ReservePaymentId,
+                        principalTable: "ReservePayment",
+                        principalColumn: "ReservePaymentId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CustomerAccountTransactions_Reserve_RelatedReserveId",
+                        column: x => x.RelatedReserveId,
+                        principalTable: "Reserve",
+                        principalColumn: "ReserveId",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 27, 22, 28, 21, 11, DateTimeKind.Utc).AddTicks(427));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 27, 22, 28, 21, 11, DateTimeKind.Utc).AddTicks(429));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomerAccountTransactions_CustomerId",
+                table: "CustomerAccountTransactions",
+                column: "CustomerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomerAccountTransactions_Date",
+                table: "CustomerAccountTransactions",
+                column: "Date");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomerAccountTransactions_RelatedReserveId",
+                table: "CustomerAccountTransactions",
+                column: "RelatedReserveId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomerAccountTransactions_ReservePaymentId",
+                table: "CustomerAccountTransactions",
+                column: "ReservePaymentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomerAccountTransactions_Type",
+                table: "CustomerAccountTransactions",
+                column: "Type");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CustomerAccountTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentBalance",
+                table: "Customer");
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 1,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 18, 4, 36, 0, 103, DateTimeKind.Utc).AddTicks(2752));
+
+            migrationBuilder.UpdateData(
+                table: "Role",
+                keyColumn: "RoleId",
+                keyValue: 2,
+                column: "CreatedDate",
+                value: new DateTime(2025, 6, 18, 4, 36, 0, 103, DateTimeKind.Utc).AddTicks(2754));
+        }
+    }
+}


### PR DESCRIPTION
Se ha añadido la propiedad `CurrentBalance` a la clase `Customer` para representar el saldo actual del cliente. Se ha creado la tabla `CustomerAccountTransactions` para almacenar las transacciones de cuentas de clientes, y se han actualizado las pruebas en `ReserveBusinessTests` para validar correctamente las transacciones de cargo y pago. Además, se han realizado cambios en la lógica de negocio en `ReserveBusiness` para manejar estas transacciones al crear reservas y procesar pagos. Se han añadido configuraciones de entidad para `CustomerAccountTransaction` y se han actualizado los métodos de migración y el modelo de datos en `ApplicationDbContextModelSnapshot`.