### PR TITLE
Añadir resumen de cuenta de cliente y mejoras asociadas

### DIFF
--- a/transport.api/Functions/CustomerFunction.cs
+++ b/transport.api/Functions/CustomerFunction.cs
@@ -80,4 +80,19 @@ public sealed class CustomerFunction : FunctionBase
         var result = await _customerBusiness.GetCustomerReport(filter);
         return await MatchResultAsync(req, result);
     }
+
+    [Function("GetCustomerAccountSummary")]
+    [Authorize("Admin")]
+    [OpenApiOperation(operationId: "customer-account-summary", tags: new[] { "Customer" }, Summary = "Get customer account summary", Description = "Returns the account summary and transactions of a customer", Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiParameter("customerId", In = ParameterLocation.Path, Required = true, Type = typeof(int), Description = "Customer ID")]
+    [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<CustomerTransactionReportFilterRequestDto>), Required = true)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(CustomerAccountSummaryDto), Summary = "Customer account summary with transactions")]
+    public async Task<HttpResponseData> GetCustomerAccountSummary(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "customer-account-summary/{customerId:int}")] HttpRequestData req,
+    int customerId)
+    {
+        var dto = await req.ReadFromJsonAsync<PagedReportRequestDto<CustomerTransactionReportFilterRequestDto>>();
+        var result = await _customerBusiness.GetCustomerAccountSummaryAsync(customerId, dto);
+        return await MatchResultAsync(req, result);
+    }
 }

--- a/transport.common/Contracts/Customer/CustomerReportResponseDto.cs
+++ b/transport.common/Contracts/Customer/CustomerReportResponseDto.cs
@@ -8,4 +8,5 @@ public record CustomerReportResponseDto(
     string DocumentNumber,
     string Phone1,
     string? Phone2,
-    DateTime CreatedDate);
+    DateTime CreatedDate,
+    decimal CurrentBalance);

--- a/transport.common/Contracts/Customer/CustomerTransactionDto.cs
+++ b/transport.common/Contracts/Customer/CustomerTransactionDto.cs
@@ -1,0 +1,17 @@
+﻿namespace Transport.SharedKernel.Contracts.Customer;
+
+public record CustomerTransactionDto(
+    int Id,
+    int CustomerId,
+    string? Description,
+    string TransactionType,
+    decimal Amount,
+    DateTime Date
+);
+
+public record CustomerAccountSummaryDto(
+    int CustomerId,
+    string CustomerFullName,
+    decimal CurrentBalance,
+    PagedReportResponseDto<CustomerTransactionDto> Transactions
+);

--- a/transport.common/Contracts/Customer/CustomerTransactionReportFilterRequestDto.cs
+++ b/transport.common/Contracts/Customer/CustomerTransactionReportFilterRequestDto.cs
@@ -1,0 +1,6 @@
+﻿namespace Transport.SharedKernel.Contracts.Customer;
+public record CustomerTransactionReportFilterRequestDto(
+    int? TransactionType,
+    DateTime? FromDate,
+    DateTime? ToDate
+);

--- a/transport.domain/Customers/Abstraction/ICustomerBusiness.cs
+++ b/transport.domain/Customers/Abstraction/ICustomerBusiness.cs
@@ -10,4 +10,5 @@ public interface ICustomerBusiness
     Task<Result<PagedReportResponseDto<CustomerReportResponseDto>>> GetCustomerReport(PagedReportRequestDto<CustomerReportFilterRequestDto> requestDto);
     Task<Result<bool>> Update(int customerId, CustomerUpdateRequestDto dto);
     Task<Result<bool>> UpdateStatus(int customerId, EntityStatusEnum status);
+    Task<Result<CustomerAccountSummaryDto>> GetCustomerAccountSummaryAsync(int customerId, PagedReportRequestDto<CustomerTransactionReportFilterRequestDto> requestDto);
 }

--- a/transport.domain/Customers/CustomerAccountTransaction.cs
+++ b/transport.domain/Customers/CustomerAccountTransaction.cs
@@ -35,8 +35,8 @@ public class CustomerAccountTransaction : Entity, IAuditable
 
 public enum TransactionType
 {
-    Charge,
-    Payment,
-    Adjustment,
-    Refund
+    Charge = 1,
+    Payment = 2,
+    Adjustment = 3,
+    Refund = 4
 }


### PR DESCRIPTION
Se ha implementado el método `GetCustomerAccountSummary` en `CustomerFunction` para obtener un resumen de la cuenta de un cliente, incluyendo transacciones.

En `CustomerBusiness`, se ha actualizado el selector del informe de clientes para incluir el saldo actual y se ha añadido el método `GetCustomerAccountSummaryAsync` para manejar la lógica de resumen de cuenta.

Se han creado los registros `CustomerTransactionDto` y `CustomerAccountSummaryDto`, y se ha añadido `CustomerTransactionReportFilterRequestDto` para gestionar los filtros de transacciones.

Además, se ha actualizado la interfaz `ICustomerBusiness` con el nuevo método y se han asignado valores numéricos a los tipos de transacción en `TransactionType` para mejorar la claridad.