### PR TITLE
Añadir CurrentBalance a ReserveBusiness y DTOs

### DIFF
--- a/transport.application/ReserveBusiness/ReserveBusiness.cs
+++ b/transport.application/ReserveBusiness/ReserveBusiness.cs
@@ -382,7 +382,8 @@ public class ReserveBusiness : IReserveBusiness
                       p.DropoffLocationId!.Value,
                       p.DropoffAddress,
                       p.PickupLocationId!.Value,
-                      p.PickupAddress))
+                      p.PickupAddress,
+                      p.Customer.CurrentBalance))
                   .ToList(),
                 rp.Service.ReservePrices.Select(p => new ReservePriceReport((int)p.ReserveTypeId, p.Price)).ToList()
             ),
@@ -437,7 +438,8 @@ public class ReserveBusiness : IReserveBusiness
                 cr.DropoffLocationId!.Value,
                 cr.DropoffAddress,
                 cr.PickupLocationId!.Value,
-                cr.PickupAddress),
+                cr.PickupAddress,
+                cr.Customer.CurrentBalance),
             sortMappings: sortMappings
         );
 

--- a/transport.common/Contracts/Reserve/CustomerReserveReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/CustomerReserveReportResponseDto.cs
@@ -11,4 +11,5 @@ public record CustomerReserveReportResponseDto(
     int DropoffLocationId,
     string? DropoffLocationName,
     int PickupLocationId,
-    string? PickupLocationName);
+    string? PickupLocationName,
+    decimal CurrentBalance);


### PR DESCRIPTION
Se ha incorporado la propiedad `CurrentBalance` en las clases `ReserveBusiness` y `CustomerReserveReportResponseDto`. Esto permite gestionar el saldo actual del cliente en los informes de reservas. También se han ajustado los objetos de reserva para incluir el `CurrentBalance` en los reportes generados.