### PR TITLE
Añadir funcionalidad para actualizar reservas de cliente

### DIFF
--- a/transport.api/Functions/ReservesFunction.cs
+++ b/transport.api/Functions/ReservesFunction.cs
@@ -147,4 +147,29 @@ public class ReservesFunction : FunctionBase
         var result = await _reserveBusiness.CreatePaymentsAsync(reserveId, customerId, payments);
         return await MatchResultAsync(req, result);
     }
+
+    [Function("UpdateCustomerReserve")]
+    [Authorize("Admin")]
+    [OpenApiOperation(
+    operationId: "customer-reserve-update",
+    tags: new[] { "CustomerReserve" },
+    Summary = "Update a Customer Reserve",
+    Description = "Updates the specified customer reserve with new pickup/dropoff locations or travel status.",
+    Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiRequestBody("application/json", typeof(CustomerReserveUpdateRequestDto), Required = true)]
+    [OpenApiParameter(name: "customerReserveId", In = ParameterLocation.Path, Required = true, Type = typeof(int), Summary = "ID of the customer reserve")]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Result<bool>), Summary = "Customer reserve updated successfully.")]
+    [OpenApiResponseWithoutBody(HttpStatusCode.NotFound, Summary = "Customer reserve not found.")]
+    public async Task<HttpResponseData> UpdateCustomerReserve(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "customer-reserve-update/{customerReserveId:int}")] HttpRequestData req,
+    int customerReserveId)
+    {
+        var dto = await req.ReadFromJsonAsync<CustomerReserveUpdateRequestDto>();
+
+        var result = await ValidateAndMatchAsync(req, dto, GetValidator<CustomerReserveUpdateRequestDto>())
+                        .BindAsync(update => _reserveBusiness.UpdateCustomerReserveAsync(customerReserveId, update));
+
+        return await MatchResultAsync(req, result);
+    }
+
 }

--- a/transport.application/Data/IApplicationDbContext.cs
+++ b/transport.application/Data/IApplicationDbContext.cs
@@ -30,5 +30,6 @@ public interface IApplicationDbContext
     DbSet<ServiceSchedule> ServiceSchedules { get; }
     DbSet<ReservePayment> ReservePayments { get; }
     DbSet<CustomerAccountTransaction> CustomerAccountTransactions { get; }
+    EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
     Task<int> SaveChangesWithOutboxAsync(CancellationToken cancellationToken = default);
 }

--- a/transport.application/ReserveBusiness/Validation/CustomerReserveUpdateRequestValidator.cs
+++ b/transport.application/ReserveBusiness/Validation/CustomerReserveUpdateRequestValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using Transport.SharedKernel.Contracts.Customer;
+
+namespace Transport.Business.ReserveBusiness.Validation;
+
+public class CustomerReserveUpdateRequestValidator : AbstractValidator<CustomerReserveUpdateRequestDto>
+{
+    public CustomerReserveUpdateRequestValidator()
+    {
+        RuleFor(x => x)
+            .Must(x =>
+                !(x.PickupLocationId.HasValue &&
+                  x.DropoffLocationId.HasValue &&
+                  x.PickupLocationId == x.DropoffLocationId))
+            .WithMessage("Pickup and dropoff locations cannot be the same.");
+    }
+}

--- a/transport.common/Contracts/Customer/CustomerReserveUpdateRequestDto.cs
+++ b/transport.common/Contracts/Customer/CustomerReserveUpdateRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Transport.SharedKernel.Contracts.Customer;
+
+public record CustomerReserveUpdateRequestDto(
+        int? PickupLocationId,
+        int? DropoffLocationId,
+        bool? HasTraveled
+    );

--- a/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
+++ b/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
@@ -21,4 +21,6 @@ public interface IReserveBusiness
     int reserveId,
     int customerId,
     List<CreatePaymentRequestDto> payments);
+
+    Task<Result<bool>> UpdateCustomerReserveAsync(int customerReserveId, CustomerReserveUpdateRequestDto request);
 }

--- a/transport.infraestructure/Database/ApplicationDbContext.cs
+++ b/transport.infraestructure/Database/ApplicationDbContext.cs
@@ -106,4 +106,6 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
         return result;
     }
 
+    public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
+            => base.Entry(entity);
 }


### PR DESCRIPTION
Se ha implementado el método `UpdateCustomerReserve` en la clase `ReservesFunction`, permitiendo la actualización de reservas con nuevas ubicaciones de recogida y entrega.

Se han agregado métodos en `IApplicationDbContext` para un mejor manejo de entidades y cambios en la base de datos.

En `ReserveBusiness`, se ha creado `UpdateCustomerReserveAsync` para buscar y actualizar reservas de cliente, incluyendo validaciones para evitar ubicaciones duplicadas.

Se ha introducido el validador `CustomerReserveUpdateRequestValidator` y el DTO `CustomerReserveUpdateRequestDto` para gestionar las actualizaciones.

Además, se ha declarado el método `UpdateCustomerReserveAsync` en la interfaz `IReserveBusiness` y se ha implementado `Entry<TEntity>` en `ApplicationDbContext`.