### PR TITLE
Añadir resumen de reservas públicas y mejoras en filtros

### DIFF
--- a/transport.api/Functions/ReservesFunction.cs
+++ b/transport.api/Functions/ReservesFunction.cs
@@ -103,6 +103,25 @@ public class ReservesFunction : FunctionBase
         return await MatchResultAsync(req, result);
     }
 
+    [Function("GetPublicReserveSummary")]
+    [AllowAnonymous]
+    [OpenApiOperation(
+    operationId: "public-reserve-summary",
+    tags: new[] { "Reserve" },
+    Summary = "Get Reserve Summary for Users",
+    Description = "Returns a grouped (outbound/return) paginated list of available reserves for final users.",
+    Visibility = OpenApiVisibilityType.Important)]
+    [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<ReserveReportFilterRequestDto>), Required = true)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ReserveGroupedPagedReportResponseDto), Summary = "Grouped Reserve Report")]
+    public async Task<HttpResponseData> GetPublicReserveSummary(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public/reserve-summary/")] HttpRequestData req,
+    string reserveDate)
+    {
+        var filter = await req.ReadFromJsonAsync<PagedReportRequestDto<ReserveReportFilterRequestDto>>();
+        var result = await _reserveBusiness.GetReserveReport(filter);
+        return await MatchResultAsync(req, result);
+    }
+
 
     [Function("GetCustomerReserveReport")]
     [Authorize("Admin")]

--- a/transport.common/Contracts/Reserve/ReserveExternalReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveExternalReportResponseDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Transport.SharedKernel.Contracts.Reserve;
+
+public record ReserveExternalReportResponseDto(int ReserveId,
+    string OriginName,
+    string DestinationName,
+    string DepartureHour,
+    decimal Price);

--- a/transport.common/Contracts/Reserve/ReserveGroupedPagedReportResponseDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveGroupedPagedReportResponseDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Transport.SharedKernel.Contracts.Reserve;
+
+public class ReserveGroupedPagedReportResponseDto
+{
+    public PagedReportResponseDto<ReserveExternalReportResponseDto> Outbound { get; set; } = new();
+    public PagedReportResponseDto<ReserveExternalReportResponseDto> Return { get; set; } = new();
+}

--- a/transport.common/Contracts/Reserve/ReserveReportFilterRequestDto.cs
+++ b/transport.common/Contracts/Reserve/ReserveReportFilterRequestDto.cs
@@ -1,3 +1,8 @@
 ﻿namespace Transport.SharedKernel.Contracts.Reserve;
 
-public record ReserveReportFilterRequestDto();
+public record ReserveReportFilterRequestDto(int OriginId, 
+    int DestinationId, 
+    string TripType, 
+    int Passengers,
+    DateTime DepartureDate,
+    DateTime? ReturnDate);

--- a/transport.common/PagedReportResponseDto.cs
+++ b/transport.common/PagedReportResponseDto.cs
@@ -8,4 +8,21 @@ public class PagedReportResponseDto<T>
     public int TotalRecords { get; set; }
 
     public int TotalPages => (int)Math.Ceiling((double)TotalRecords / PageSize);
+
+    public static PagedReportResponseDto<T> Create(List<T> allItems, int pageNumber, int pageSize)
+    {
+        var totalItems = allItems.Count;
+        var pagedItems = allItems
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new PagedReportResponseDto<T>
+        {
+            Items = pagedItems,
+            TotalRecords = totalItems,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
+    }
 }

--- a/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
+++ b/transport.domain/Reserves/Abstraction/IReserveBusiness.cs
@@ -26,4 +26,5 @@ public interface IReserveBusiness
 
     Task<Result<bool>> UpdateCustomerReserveAsync(int customerReserveId, CustomerReserveUpdateRequestDto request);
     Task<Result<bool>> UpdateReservePaymentsByExternalId(string externalId);
+    Task<Result<ReserveGroupedPagedReportResponseDto>> GetReserveReport(PagedReportRequestDto<ReserveReportFilterRequestDto> requestDto);
 }


### PR DESCRIPTION
Se ha implementado el método `GetPublicReserveSummary` en `ReservesFunction` para obtener un resumen de reservas públicas. Se ha modificado `GetReserveReport` en `ReserveBusiness` para aceptar un nuevo DTO y devolver un resultado agrupado.

Se han introducido las clases `ReserveExternalReportResponseDto` y `ReserveGroupedPagedReportResponseDto` para estructurar las respuestas. Además, se han añadido propiedades en `ReserveReportFilterRequestDto` para mejorar el filtrado de reservas.

Se ha implementado un método estático `Create` en `PagedReportResponseDto<T>` para facilitar la paginación y se ha actualizado la interfaz `IReserveBusiness` para reflejar estos cambios.