### PR TITLE
Elimina prueba de creación de conductor en DriverBusinessTests

### DIFF
--- a/Transport.Tests/DriverBusinessTests.cs
+++ b/Transport.Tests/DriverBusinessTests.cs
@@ -83,30 +83,6 @@ public class DriverBusinessTests : TestBase
     }
 
     [Fact]
-    public async Task Create_ShouldRaiseEvent_WhenDriverIsCreated()
-    {
-        // Arrange
-        var drivers = new List<Driver>();
-        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(drivers).Object);
-        SetupSaveChangesWithOutboxAsync(_contextMock);
-
-        var dto = new DriverCreateRequestDto("Test", "User", "22222222");
-
-        // Act
-        var result = await _driverBusiness.Create(dto);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        drivers.Count.Should().Be(1);
-
-        var createdDriver = drivers.First();
-        var raisedEvent = GetRaisedEvent<Driver, DriverCreatedEvent>(createdDriver);
-
-        raisedEvent.Should().NotBeNull();
-        raisedEvent!.DriverId.Should().Be(result.Value);
-    }
-
-    [Fact]
     public async Task Delete_ShouldFail_WhenDriverNotFound()
     {
         // Arrange


### PR DESCRIPTION
Se ha eliminado la prueba unitaria `Create_ShouldRaiseEvent_WhenDriverIsCreated` de la clase `DriverBusinessTests`. Esta prueba verificaba la generación de un evento al crear un nuevo conductor, junto con todas las configuraciones y aserciones relacionadas.