### PR TITLE
Permitir acceso anónimo a funciones de ciudad y reservas

### DIFF
--- a/transport.api/Functions/CityFunction.cs
+++ b/transport.api/Functions/CityFunction.cs
@@ -89,7 +89,7 @@ public sealed class CityFunction : FunctionBase
     }
 
     [Function("GetCityReport")]
-    [Authorize("Admin")]
+    [AllowAnonymous]
     [OpenApiOperation(operationId: "city-report", tags: new[] { "City" }, Summary = "Get City Report", Description = "Returns paginated list of Citys", Visibility = OpenApiVisibilityType.Important)]
     [OpenApiRequestBody("application/json", typeof(PagedReportRequestDto<CityReportFilterRequestDto>), Required = true)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(PagedReportResponseDto<CityReportResponseDto>), Summary = "City Report")]

--- a/transport.api/Functions/ReservesFunction.cs
+++ b/transport.api/Functions/ReservesFunction.cs
@@ -53,7 +53,7 @@ public class ReservesFunction : FunctionBase
     }
 
     [Function("CreatePassengerReserveExternal")]
-    [Authorize("Admin")]
+    [AllowAnonymous]
     [OpenApiOperation(
     operationId: "passenger-reserves-create",
     tags: new[] { "Reserve" },


### PR DESCRIPTION
Se han actualizado las clases `CityFunction` y `ReservesFunction` para cambiar el atributo de autorización de `[Authorize("Admin")]` a `[AllowAnonymous]`. Esto permite que cualquier usuario acceda a las funciones `GetCityReport` y `CreatePassengerReserveExternal` sin necesidad de autenticación previa.