### PR TITLE
Validaciones de borrado y mejoras en reportes y choferes

### DIFF
--- a/Transport.Tests/CityBusinessTest.cs
+++ b/Transport.Tests/CityBusinessTest.cs
@@ -73,12 +73,32 @@ public class CityBusinessTests : TestBase
         var city = new City { CityId = 1, Status = EntityStatusEnum.Active };
         _contextMock.Setup(x => x.Cities)
             .Returns(GetQueryableMockDbSet(new List<City> { city }));
+        _contextMock.Setup(x => x.Directions)
+            .Returns(GetQueryableMockDbSet(new List<Direction>()));
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
         var result = await _CityBusiness.Delete(1);
 
         result.IsSuccess.Should().BeTrue();
         city.Status.Should().Be(EntityStatusEnum.Deleted);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldFail_WhenCityHasActiveDirections()
+    {
+        var city = new City { CityId = 1, Status = EntityStatusEnum.Active };
+        var direction = new Direction { DirectionId = 1, CityId = 1, Status = EntityStatusEnum.Active };
+
+        _contextMock.Setup(x => x.Cities)
+            .Returns(GetQueryableMockDbSet(new List<City> { city }));
+        _contextMock.Setup(x => x.Directions)
+            .Returns(GetQueryableMockDbSet(new List<Direction> { direction }));
+
+        var result = await _CityBusiness.Delete(1);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(CityError.HasDirections);
+        city.Status.Should().Be(EntityStatusEnum.Active);
     }
 
     [Fact]

--- a/Transport.Tests/DriverBusinessTests.cs
+++ b/Transport.Tests/DriverBusinessTests.cs
@@ -104,6 +104,55 @@ public class DriverBusinessTests : TestBase
         var drivers = new List<Driver> { driver };
 
         _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(drivers));
+        _contextMock.Setup(x => x.Reserves).Returns(GetQueryableMockDbSet(new List<Reserve>()));
+        SetupSaveChangesWithOutboxAsync(_contextMock);
+
+        // Act
+        var result = await _driverBusiness.Delete(1);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        driver.Status.Should().Be(EntityStatusEnum.Deleted);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldFail_WhenDriverHasFutureReserves()
+    {
+        // Arrange
+        var driver = new Driver { DriverId = 1, Status = EntityStatusEnum.Active };
+        var futureReserve = new Reserve
+        {
+            DriverId = 1,
+            ReserveDate = DateTime.UtcNow.Date.AddDays(3),
+            Status = ReserveStatusEnum.Confirmed
+        };
+
+        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(new List<Driver> { driver }));
+        _contextMock.Setup(x => x.Reserves).Returns(GetQueryableMockDbSet(new List<Reserve> { futureReserve }));
+
+        // Act
+        var result = await _driverBusiness.Delete(1);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(DriverError.HasFutureReserves);
+        driver.Status.Should().Be(EntityStatusEnum.Active);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldSucceed_WhenDriverHasOnlyPastReserves()
+    {
+        // Arrange
+        var driver = new Driver { DriverId = 1, Status = EntityStatusEnum.Active };
+        var pastReserve = new Reserve
+        {
+            DriverId = 1,
+            ReserveDate = DateTime.UtcNow.Date.AddDays(-5),
+            Status = ReserveStatusEnum.Completed
+        };
+
+        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(new List<Driver> { driver }));
+        _contextMock.Setup(x => x.Reserves).Returns(GetQueryableMockDbSet(new List<Reserve> { pastReserve }));
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
         // Act
@@ -120,7 +169,7 @@ public class DriverBusinessTests : TestBase
         var drivers = new List<Driver>();
         _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(drivers));
 
-        var dto = new DriverUpdateRequestDto("NuevoNombre", "NuevoApellido");
+        var dto = new DriverUpdateRequestDto("NuevoNombre", "NuevoApellido", "12345678");
 
         var result = await _driverBusiness.Update(42, dto);
 
@@ -131,18 +180,76 @@ public class DriverBusinessTests : TestBase
     [Fact]
     public async Task Update_ShouldModifyDriver_WhenExists()
     {
-        var driver = new Driver { DriverId = 1, FirstName = "Original", LastName = "Original" };
+        var driver = new Driver { DriverId = 1, FirstName = "Original", LastName = "Original", DocumentNumber = "11111111" };
         var drivers = new List<Driver> { driver };
         _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(drivers));
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
-        var dto = new DriverUpdateRequestDto("Editado", "ApellidoEditado");
+        var dto = new DriverUpdateRequestDto("Editado", "ApellidoEditado", "11111111");
 
         var result = await _driverBusiness.Update(1, dto);
 
         result.IsSuccess.Should().BeTrue();
         driver.FirstName.Should().Be("Editado");
         driver.LastName.Should().Be("ApellidoEditado");
+    }
+
+    [Fact]
+    public async Task Update_ShouldUpdateDocumentNumber_WhenChanged()
+    {
+        var driver = new Driver { DriverId = 1, FirstName = "Juan", LastName = "Perez", DocumentNumber = "11111111" };
+        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(new List<Driver> { driver }));
+        SetupSaveChangesWithOutboxAsync(_contextMock);
+
+        var dto = new DriverUpdateRequestDto("Juan", "Perez", "22222222");
+
+        var result = await _driverBusiness.Update(1, dto);
+
+        result.IsSuccess.Should().BeTrue();
+        driver.DocumentNumber.Should().Be("22222222");
+    }
+
+    [Fact]
+    public async Task Update_ShouldFail_WhenDocumentNumberAlreadyUsedByAnotherDriver()
+    {
+        var target = new Driver { DriverId = 1, FirstName = "Juan", LastName = "Perez", DocumentNumber = "11111111" };
+        var other = new Driver { DriverId = 2, FirstName = "Ana", LastName = "Lopez", DocumentNumber = "22222222" };
+        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(new List<Driver> { target, other }));
+
+        var dto = new DriverUpdateRequestDto("Juan", "Perez", "22222222");
+
+        var result = await _driverBusiness.Update(1, dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(DriverError.DriverAlreadyExist);
+        target.DocumentNumber.Should().Be("11111111");
+    }
+
+    [Fact]
+    public async Task GetDriverReport_ShouldExcludeDeleted_WhenStatusNotProvided()
+    {
+        var drivers = new List<Driver>
+        {
+            new Driver { DriverId = 1, FirstName = "Active", LastName = "One", DocumentNumber = "11111111", Status = EntityStatusEnum.Active, Reserves = new List<Reserve>() },
+            new Driver { DriverId = 2, FirstName = "Deleted", LastName = "Two", DocumentNumber = "22222222", Status = EntityStatusEnum.Deleted, Reserves = new List<Reserve>() }
+        };
+
+        _contextMock.Setup(x => x.Drivers).Returns(GetQueryableMockDbSet(drivers));
+
+        var requestDto = new PagedReportRequestDto<DriverReportFilterRequestDto>
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            Filters = new DriverReportFilterRequestDto(),
+            SortBy = "firstname",
+            SortDescending = false
+        };
+
+        var result = await _driverBusiness.GetDriverReport(requestDto);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Items.Should().HaveCount(1);
+        result.Value.Items.First().DriverId.Should().Be(1);
     }
 
     [Fact]

--- a/Transport.Tests/VehicleTypeBusinessTest.cs
+++ b/Transport.Tests/VehicleTypeBusinessTest.cs
@@ -111,12 +111,32 @@ public class VehicleTypeBusinessTests : TestBase
         var vehicleType = new VehicleType { VehicleTypeId = 1, Status = EntityStatusEnum.Active };
         _contextMock.Setup(x => x.VehicleTypes)
             .Returns(GetQueryableMockDbSet(new List<VehicleType> { vehicleType }));
+        _contextMock.Setup(x => x.Vehicles)
+            .Returns(GetQueryableMockDbSet(new List<Vehicle>()));
         SetupSaveChangesWithOutboxAsync(_contextMock);
 
         var result = await _vehicleTypeBusiness.Delete(1);
 
         result.IsSuccess.Should().BeTrue();
         vehicleType.Status.Should().Be(EntityStatusEnum.Deleted);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldFail_WhenVehicleTypeHasActiveVehicles()
+    {
+        var vehicleType = new VehicleType { VehicleTypeId = 1, Status = EntityStatusEnum.Active };
+        var vehicle = new Vehicle { VehicleId = 1, VehicleTypeId = 1, Status = EntityStatusEnum.Active };
+
+        _contextMock.Setup(x => x.VehicleTypes)
+            .Returns(GetQueryableMockDbSet(new List<VehicleType> { vehicleType }));
+        _contextMock.Setup(x => x.Vehicles)
+            .Returns(GetQueryableMockDbSet(new List<Vehicle> { vehicle }));
+
+        var result = await _vehicleTypeBusiness.Delete(1);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(VehicleTypeError.InUse);
+        vehicleType.Status.Should().Be(EntityStatusEnum.Active);
     }
 
     [Fact]

--- a/transport.api/.claude/settings.local.json
+++ b/transport.api/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//c/Users/x/Documents/GitHub/transport-api/**)",
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)"
+    ],
+    "additionalDirectories": [
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\CityBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\TripBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\ServiceBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.common\\Contracts\\Driver",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.common\\Contracts\\Customer",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\DriverBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\CustomerBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.domain\\Cities",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.domain\\Drivers",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.domain\\Vehicles",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\transport.application\\VehicleTypeBusiness",
+      "c:\\Users\\x\\Documents\\GitHub\\transport-api\\Transport.Tests"
+    ]
+  }
+}

--- a/transport.api/transport.api.sln
+++ b/transport.api/transport.api.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Transport.Api", "Transport.Api.csproj", "{92A210CA-A67E-B011-7E7E-CDA83718A4F0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{92A210CA-A67E-B011-7E7E-CDA83718A4F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92A210CA-A67E-B011-7E7E-CDA83718A4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92A210CA-A67E-B011-7E7E-CDA83718A4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92A210CA-A67E-B011-7E7E-CDA83718A4F0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0DC1C698-0F98-4BD6-BC22-35D1EC3C4FA5}
+	EndGlobalSection
+EndGlobal

--- a/transport.application/CityBusiness/CityBusiness.cs
+++ b/transport.application/CityBusiness/CityBusiness.cs
@@ -55,6 +55,14 @@ public class CityBusiness : ICityBusiness
             return Result.Failure<bool>(CityError.CityNotFound);
         }
 
+        var hasDirections = await _context.Directions
+            .AnyAsync(d => d.CityId == cityId && d.Status == EntityStatusEnum.Active);
+
+        if (hasDirections)
+        {
+            return Result.Failure<bool>(CityError.HasDirections);
+        }
+
         city.Status = EntityStatusEnum.Deleted;
 
         await _context.SaveChangesWithOutboxAsync();
@@ -82,6 +90,8 @@ public class CityBusiness : ICityBusiness
 
         if (requestDto.Filters?.Status is not null)
             query = query.Where(v => v.Status == requestDto.Filters.Status);
+        else
+            query = query.Where(v => v.Status == EntityStatusEnum.Active);
 
         var sortMappings = new Dictionary<string, Expression<Func<City, object>>>
         {

--- a/transport.application/CustomerBusiness/CustomerBusiness.cs
+++ b/transport.application/CustomerBusiness/CustomerBusiness.cs
@@ -99,6 +99,11 @@ public class CustomerBusiness : ICustomerBusiness
         if (!string.IsNullOrWhiteSpace(requestDto.Filters?.DocumentNumber))
             query = query.Where(x => x.DocumentNumber.Contains(requestDto.Filters.DocumentNumber));
 
+        if (requestDto.Filters?.Status is not null)
+            query = query.Where(x => x.Status == requestDto.Filters.Status);
+        else
+            query = query.Where(x => x.Status == EntityStatusEnum.Active);
+
         var sortMappings = new Dictionary<string, Expression<Func<Customer, object>>>
         {
             ["firstname"] = c => c.FirstName,

--- a/transport.application/DriverBusiness/DriverBusiness.cs
+++ b/transport.application/DriverBusiness/DriverBusiness.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using Transport.SharedKernel.Contracts.City;
 using Transport.Domain.Vehicles;
 using Transport.Domain.Cities;
+using Transport.Domain.Reserves;
 
 namespace Transport.Business.DriverBusiness;
 
@@ -57,6 +58,17 @@ public class DriverBusiness : IDriverBusiness
             return Result.Failure<bool>(DriverError.DriverNotFound);
         }
 
+        var today = DateTime.UtcNow.Date;
+        var hasFutureReserves = await _context.Reserves
+            .AnyAsync(r => r.DriverId == driverId
+                        && r.ReserveDate >= today
+                        && r.Status != ReserveStatusEnum.Cancelled);
+
+        if (hasFutureReserves)
+        {
+            return Result.Failure<bool>(DriverError.HasFutureReserves);
+        }
+
         driver.Status = EntityStatusEnum.Deleted;
 
         _context.Drivers.Update(driver);
@@ -81,6 +93,11 @@ public class DriverBusiness : IDriverBusiness
 
         if (!string.IsNullOrWhiteSpace(requestDto.Filters?.DocumentNumber))
             query = query.Where(x => x.DocumentNumber.Contains(requestDto.Filters.DocumentNumber));
+
+        if (requestDto.Filters?.Status is not null)
+            query = query.Where(x => x.Status == requestDto.Filters.Status);
+        else
+            query = query.Where(x => x.Status == EntityStatusEnum.Active);
 
         var sortMappings = new Dictionary<string, Expression<Func<Driver, object>>>
         {
@@ -118,6 +135,19 @@ public class DriverBusiness : IDriverBusiness
         if (driver is null)
         {
             return Result.Failure<bool>(DriverError.DriverNotFound);
+        }
+
+        if (driver.DocumentNumber != dto.DocumentNumber)
+        {
+            var duplicate = await _context.Drivers
+                .AnyAsync(x => x.DocumentNumber == dto.DocumentNumber && x.DriverId != driverId);
+
+            if (duplicate)
+            {
+                return Result.Failure<bool>(DriverError.DriverAlreadyExist);
+            }
+
+            driver.DocumentNumber = dto.DocumentNumber;
         }
 
         driver.FirstName = dto.FirstName;

--- a/transport.application/DriverBusiness/Validation/DriverCreateRequestValidator.cs
+++ b/transport.application/DriverBusiness/Validation/DriverCreateRequestValidator.cs
@@ -25,6 +25,8 @@ public class DriverCreateRequestValidator : AbstractValidator<DriverCreateReques
         RuleFor(p => p.documentNumber)
             .NotEmpty()
             .WithMessage("Document number is required")
+            .MaximumLength(20)
+            .WithMessage("Document number must not exceed 20 characters")
             .Matches(@"^\d{8,10}$")
             .WithMessage("Document number must be between 8 and 10 digits");
     }

--- a/transport.application/DriverBusiness/Validation/DriverUpdateRequestValidator.cs
+++ b/transport.application/DriverBusiness/Validation/DriverUpdateRequestValidator.cs
@@ -22,5 +22,13 @@ public class DriverUpdateRequestValidator : AbstractValidator<DriverUpdateReques
             .WithMessage("Last name must be at least 2 characters long")
             .MaximumLength(50)
             .WithMessage("Last name must not exceed 50 characters");
+
+        RuleFor(p => p.DocumentNumber)
+            .NotEmpty()
+            .WithMessage("Document number is required")
+            .MaximumLength(20)
+            .WithMessage("Document number must not exceed 20 characters")
+            .Matches(@"^\d{8,10}$")
+            .WithMessage("Document number must be between 8 and 10 digits");
     }
 }

--- a/transport.application/ServiceBusiness/ServiceBusiness.cs
+++ b/transport.application/ServiceBusiness/ServiceBusiness.cs
@@ -112,6 +112,8 @@ public class ServiceBusiness : IServiceBusiness
 
         if (requestDto.Filters?.Status is not null)
             query = query.Where(s => s.Status == requestDto.Filters.Status);
+        else
+            query = query.Where(s => s.Status == EntityStatusEnum.Active);
 
         var sortMappings = new Dictionary<string, Expression<Func<Service, object>>>
         {

--- a/transport.application/TripBusiness/TripBusiness.cs
+++ b/transport.application/TripBusiness/TripBusiness.cs
@@ -145,6 +145,8 @@ public class TripBusiness : ITripBusiness
 
         if (request.Filters?.Status is not null)
             query = query.Where(t => t.Status == request.Filters.Status);
+        else
+            query = query.Where(t => t.Status == EntityStatusEnum.Active);
 
         var sortMappings = new Dictionary<string, Expression<Func<Trip, object>>>
         {

--- a/transport.application/VehicleTypeBusiness/VehicleTypeBusiness.cs
+++ b/transport.application/VehicleTypeBusiness/VehicleTypeBusiness.cs
@@ -60,6 +60,14 @@ public class VehicleTypeBusiness : IVehicleTypeBusiness
             return Result.Failure<bool>(VehicleError.VehicleNotFound);
         }
 
+        var inUse = await _context.Vehicles
+            .AnyAsync(v => v.VehicleTypeId == vehicleTypeId && v.Status == EntityStatusEnum.Active);
+
+        if (inUse)
+        {
+            return Result.Failure<bool>(VehicleTypeError.InUse);
+        }
+
         vehicleType.Status = EntityStatusEnum.Deleted;
         await _context.SaveChangesWithOutboxAsync();
 

--- a/transport.common/Contracts/Customer/CustomerReportFilterRequestDto.cs
+++ b/transport.common/Contracts/Customer/CustomerReportFilterRequestDto.cs
@@ -8,4 +8,5 @@ public record CustomerReportFilterRequestDto(
     string? Phone1,
     string? Phone2,
     DateTime? CreatedFrom,
-    DateTime? CreatedTo);
+    DateTime? CreatedTo,
+    EntityStatusEnum? Status = null);

--- a/transport.common/Contracts/Driver/DriverReportFilterRequestDto.cs
+++ b/transport.common/Contracts/Driver/DriverReportFilterRequestDto.cs
@@ -6,4 +6,5 @@ public class DriverReportFilterRequestDto
     public string FirstName { get; set; } = null!;
     public string LastName { get; set; } = null!;
     public string DocumentNumber { get; set; } = null!;
+    public EntityStatusEnum? Status { get; set; }
 }

--- a/transport.common/Contracts/Driver/DriverUpdateRequestDto.cs
+++ b/transport.common/Contracts/Driver/DriverUpdateRequestDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace Transport.SharedKernel.Contracts.Driver;
 
-public record DriverUpdateRequestDto(string FirstName, string LastName);
+public record DriverUpdateRequestDto(string FirstName, string LastName, string DocumentNumber);

--- a/transport.domain/Cities/CityError.cs
+++ b/transport.domain/Cities/CityError.cs
@@ -11,4 +11,8 @@ public static class CityError
     public static readonly Error CityAlreadyExist = Error.Validation(
         "City.Code",
         "Hay una Ciudad que ya éxiste con esta información");
+
+    public static readonly Error HasDirections = Error.Conflict(
+        "City.HasDirections",
+        "No se puede eliminar una ciudad con direcciones asociadas.");
 }

--- a/transport.domain/Drivers/DriverError.cs
+++ b/transport.domain/Drivers/DriverError.cs
@@ -16,4 +16,8 @@ public static class DriverError
     public static readonly Error DriverAlreadyExist = Error.Validation(
         "Driver.Document",
         "Hay un chofer que ya éxiste con este documento");
+
+    public static readonly Error HasFutureReserves = Error.Conflict(
+        "Driver.HasFutureReserves",
+        "No se puede eliminar un chofer con viajes futuros asignados.");
 }

--- a/transport.domain/Vehicles/VehicleTypeError.cs
+++ b/transport.domain/Vehicles/VehicleTypeError.cs
@@ -10,4 +10,8 @@ public static class VehicleTypeError
         "El Véhiculo no se encuentra Activo",
         ErrorType.Validation
     );
+
+    public static readonly Error InUse = Error.Conflict(
+        "VehicleType.InUse",
+        "No se puede eliminar un tipo de vehículo asignado a coches activos.");
 }


### PR DESCRIPTION
- Se impide eliminar ciudades con direcciones, choferes con reservas futuras y tipos de vehículo en uso.
- Los reportes ahora excluyen entidades eliminadas por defecto.
- Se amplía DriverUpdateRequestDto para incluir y validar DocumentNumber.
- Nuevos tests unitarios para coberturas de negocio y validaciones.
- Se agregan errores de dominio para nuevos casos de conflicto.
- Ajustes en validaciones de DocumentNumber en DTOs de chofer.
- Se añaden archivos de configuración y solución para el proyecto.